### PR TITLE
Replace Machinist Summon with Overdrive when deployed

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -110,6 +110,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot or Scattergun with Auto Crossbow when overheated", 31)]
         MachinistSpreadShotFeature = 1L << 24,
 
+        [CustomComboInfo("Overdrive when summoned", "Replace Rook/Queen with their respective Overdrives when summoned", 31)]
+        MachinistOverdriveFeature = 1L << 31,
+
         [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast when overheated", 31)]
         MachinistOverheatFeature = 1L << 47,
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -559,6 +559,25 @@ namespace XIVComboPlugin
                     return MCH.SpreadShot;
                 }
 
+            // Replace Rook/Queen with Overdrive when deployed
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistOverdriveFeature))
+            {
+                if (actionID == MCH.Rook || actionID == MCH.Queen)
+                {
+                    if (XIVComboPlugin.JobGauges.Get<MCHGauge>().IsRobotActive)
+                    {
+                        if (level >= 80)
+                            return MCH.QueenOverdrive;
+                        else
+                            return MCH.RookOverdrive;
+                    }
+                    if (level >= 80)
+                        return MCH.Queen;
+                    else
+                        return MCH.Rook;
+                }
+            }
+
             // BLACK MAGE
 
             // B4 and F4 change to each other depending on stance, as do Flare and Freeze.

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -13,6 +13,10 @@
             HeatBlast = 7410,
             SpreadShot = 2870,
             AutoCrossbow = 16497,
-            Scattergun = 25786;
+            Scattergun = 25786,
+            Rook = 2864,
+            RookOverdrive = 7415,
+            Queen = 16501,
+            QueenOverdrive = 16502;
     }
 }


### PR DESCRIPTION
This PR allows for the Rook Autoturret/Automaton Queen summon abilities to be replaced by their respective Overdrive abilities when the summon is on the field.

Since:
 - The Overdrives are only able to be used when the summon is currently active on the field.
 - Only one summon can be active at a time.
 - Wildfire and Detonator already replace each other without this mod.

This PR would not run into any issues where a Summon or Overdrive would need to be used irrespective of each other, would allow for the Overdrive ability to be taken off the hotbar, and make it so that the Summon/Overdrive abilities mirror how Wildfire/Detonator already work.