### PR TITLE
Refactor Job Action System

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -1,17 +1,12 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using Dalamud.Data;
 using Dalamud.Game;
 using Dalamud.Game.ClientState;
 using Dalamud.Hooking;
-using XIVComboPlugin.JobActions;
-using Dalamud.Game.ClientState.JobGauge.Enums;
-using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Logging;
-using Dalamud.Data;
-using XIVCombo.JobActions;
+using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Linq;
+using System.Runtime.InteropServices;
+using XIVCombo.JobActions;
 
 namespace XIVComboPlugin
 {
@@ -58,26 +53,6 @@ namespace XIVComboPlugin
 			checkerHook = Hook<OnCheckIsIconReplaceableDelegate>.FromAddress(Address.IsIconReplaceable, CheckIsIconReplaceableDetour);
 
 			jobsMap = Job.Initialize(clientState, Configuration, iconHook);
-			
-			/*
-			jobsMap["DRG"] = new DRG();
-			jobsMap["DRK"] = new DRK();
-			jobsMap["PLD"] = new PLD();
-			jobsMap["WAR"] = new WAR();
-			jobsMap["SAM"] = new SAM();
-			jobsMap["NIN"] = new NIN();
-			jobsMap["GNB"] = new GNB();
-			jobsMap["MCH"] = new MCH();
-			jobsMap["BLM"] = new BLM();
-			jobsMap["AST"] = new AST();
-			jobsMap["SMN"] = new SMN();
-			jobsMap["SCH"] = new SCH();
-			jobsMap["DNC"] = new DNC();
-			jobsMap["WHM"] = new WHM();
-			jobsMap["BRD"] = new BRD();
-			jobsMap["RDM"] = new RDM();
-			jobsMap["RPR"] = new RPR();
-			*/
 		}
 
 		public void Enable()

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -8,909 +8,121 @@ using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Logging;
 using Dalamud.Data;
+using XIVCombo.JobActions;
+using System.Collections.Generic;
+using System.Threading;
+using System.Linq;
 
 namespace XIVComboPlugin
 {
-    public class IconReplacer
-    {
-        public delegate ulong OnCheckIsIconReplaceableDelegate(uint actionID);
-
-        public delegate ulong OnGetIconDelegate(byte param1, uint param2);
-
-        private readonly IconReplacerAddressResolver Address;
-        private readonly Hook<OnCheckIsIconReplaceableDelegate> checkerHook;
-        private readonly ClientState clientState;
-
-        private readonly IntPtr comboTimer;
-
-        private readonly XIVComboConfiguration Configuration;
-
-        private readonly Hook<OnGetIconDelegate> iconHook;
-        private readonly IntPtr lastComboMove;
-
-        private unsafe delegate int* getArray(long* address);
-
-        public IconReplacer(SigScanner scanner, ClientState clientState, DataManager manager, XIVComboConfiguration configuration)
-        {
-
-            Configuration = configuration;
-            this.clientState = clientState;
-
-            Address = new IconReplacerAddressResolver();
-            Address.Setup(scanner);
-
-            comboTimer = Address.ComboTimer;
-            lastComboMove = comboTimer + 0x4;
-
-            PluginLog.Verbose("===== X I V C O M B O =====");
-            PluginLog.Verbose("IsIconReplaceable address {IsIconReplaceable}", Address.IsIconReplaceable);
-            PluginLog.Verbose("GetIcon address {GetIcon}", Address.GetIcon);
-            PluginLog.Verbose("ComboTimer address {ComboTimer}", comboTimer);
-            PluginLog.Verbose("LastComboMove address {LastComboMove}", lastComboMove);
-
-            iconHook = Hook<OnGetIconDelegate>.FromAddress(Address.GetIcon, GetIconDetour);
-            checkerHook = Hook<OnCheckIsIconReplaceableDelegate>.FromAddress(Address.IsIconReplaceable, CheckIsIconReplaceableDetour);
-        }
-
-        public void Enable()
-        {
-            iconHook.Enable();
-            checkerHook.Enable();
-        }
-
-        public void Dispose()
-        {
-            iconHook.Dispose();
-            checkerHook.Dispose();
-
-        }
-
-        // I hate this function. This is the dumbest function to exist in the game. Just return 1.
-        // Determines which abilities are allowed to have their icons updated.
-        private ulong CheckIsIconReplaceableDetour(uint actionID)
-        {
-            return 1;
-        }
-
-        /// <summary>
-        ///     Replace an ability with another ability
-        ///     actionID is the original ability to be "used"
-        ///     Return either actionID (itself) or a new Action table ID as the
-        ///     ability to take its place.
-        ///     I tend to make the "combo chain" button be the last move in the combo
-        ///     For example, Souleater combo on DRK happens by dragging Souleater
-        ///     onto your bar and mashing it.
-        /// </summary>
-        private ulong GetIconDetour(byte self, uint actionID)
-        {
-            if (clientState.LocalPlayer == null) return iconHook.Original(self, actionID);
-
-            var lastMove = Marshal.ReadInt32(lastComboMove);
-            var comboTime = Marshal.PtrToStructure<float>(comboTimer);
-            var level = clientState.LocalPlayer.Level;
-
-            // DRAGOON
-
-            // Change Jump/High Jump into Mirage Dive when Dive Ready
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
-                if (actionID == DRG.Jump || actionID == DRG.HighJump)
-                {
-                    if (SearchBuffArray(1243))
-                        return DRG.MirageDive;
-                    return iconHook.Original(self, DRG.Jump);
-                }
-
-            // Replace Coerthan Torment with Coerthan Torment combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonCoerthanTormentCombo))
-                if (actionID == DRG.CTorment)
-                {
-                    if (comboTime > 0)
-                    {
-                        if ((lastMove == DRG.DoomSpike || lastMove == DRG.DraconianFury) && level >= 62)
-                            return DRG.SonicThrust;
-                        if (lastMove == DRG.SonicThrust && level >= 72)
-                            return DRG.CTorment;
-                    }
-                    
-                    return iconHook.Original(self, DRG.DoomSpike);
-                }
-
-            // Replace Chaos Thrust with the Chaos Thrust combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonChaosThrustCombo))
-                if (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring)
-                {
-                    if (comboTime > 0)
-                    {
-                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 18)
-                            return DRG.Disembowel;
-                        if (lastMove == DRG.Disembowel)
-                        {
-                            if (level >= 86)
-                                return DRG.ChaoticSpring;
-                            if (level >= 50)
-                                return DRG.ChaosThrust;
-                        }
-                    }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
-                        return DRG.FangAndClaw;
-                    if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
-                        return DRG.WheelingThrust;
-                    if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
-                        return DRG.RaidenThrust;
-
-                    return DRG.TrueThrust;
-                }
-
-            // Replace Full Thrust with the Full Thrust combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonFullThrustCombo))
-                if (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)
-                {
-                    if (comboTime > 0)
-                    {
-                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 4)
-                            return DRG.VorpalThrust;
-                        if (lastMove == DRG.VorpalThrust)
-                        {
-                            if (level >= 86)
-                                return DRG.HeavensThrust;
-                            if (level >= 26)
-                                return DRG.FullThrust;
-                        }
-                    }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
-                        return DRG.FangAndClaw;
-                    if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
-                        return DRG.WheelingThrust;
-                    if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
-                        return DRG.RaidenThrust;
-
-                    return DRG.TrueThrust;
-                }
-
-            // DARK KNIGHT
-
-            // Replace Souleater with Souleater combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DarkSouleaterCombo))
-                if (actionID == DRK.Souleater)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == DRK.HardSlash && level >= 2)
-                            return DRK.SyphonStrike;
-                        if (lastMove == DRK.SyphonStrike && level >= 26)
-                            return DRK.Souleater;
-                    }
-
-                    return DRK.HardSlash;
-                }
-
-            // Replace Stalwart Soul with Stalwart Soul combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DarkStalwartSoulCombo))
-                if (actionID == DRK.StalwartSoul)
-                {
-                    if (comboTime > 0)
-                        if (lastMove == DRK.Unleash && level >= 40)
-                            return DRK.StalwartSoul;
-
-                    return DRK.Unleash;
-                }
-
-            // PALADIN
-
-            // Replace Goring Blade with Goring Blade combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinGoringBladeCombo))
-                if (actionID == PLD.GoringBlade)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == PLD.FastBlade && level >= 4)
-                            return PLD.RiotBlade;
-                        if (lastMove == PLD.RiotBlade && level >= 54)
-                            return PLD.GoringBlade;
-                    }
-
-                    return PLD.FastBlade;
-                }
-
-            // Replace Royal Authority with Royal Authority combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRoyalAuthorityCombo))
-                if (actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == PLD.FastBlade && level >= 4)
-                            return PLD.RiotBlade;
-                        if (lastMove == PLD.RiotBlade)
-                        {
-                            if (level >= 60)
-                                return PLD.RoyalAuthority;
-                            if (level >= 26)
-                                return PLD.RageOfHalone;
-                        }
-                    }
-
-                    return PLD.FastBlade;
-                }
-
-            // Replace Prominence with Prominence combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinProminenceCombo))
-                if (actionID == PLD.Prominence)
-                {
-                    if (comboTime > 0)
-                        if (lastMove == PLD.TotalEclipse && level >= 40)
-                            return PLD.Prominence;
-
-                    return PLD.TotalEclipse;
-                }
-
-            // Replace Requiescat with Confiteor when under the effect of Requiescat
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRequiescatCombo))
-                if (actionID == PLD.Requiescat)
-                {
-                    if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
-                        return PLD.Confiteor;
-
-                    if (SearchBuffArray(PLD.BuffBladeOfFaithReady))
-                        return PLD.BladeOfFaith;
-
-                    if (lastMove == PLD.BladeOfFaith)
-                        return PLD.BladeOfTruth;
-
-                    if (lastMove == PLD.BladeOfTruth)
-                        return PLD.BladeOfValor;
-
-                    return PLD.Requiescat;
-                }
-
-            // WARRIOR
-
-            // Replace Storm's Path with Storm's Path combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorStormsPathCombo))
-                if (actionID == WAR.StormsPath)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == WAR.HeavySwing && level >= 4)
-                            return WAR.Maim;
-                        if (lastMove == WAR.Maim && level >= 26)
-                            return WAR.StormsPath;
-                    }
-
-                    return WAR.HeavySwing;
-                }
-
-            // Replace Storm's Eye with Storm's Eye combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorStormsEyeCombo))
-                if (actionID == WAR.StormsEye)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == WAR.HeavySwing && level >= 4)
-                            return WAR.Maim;
-                        if (lastMove == WAR.Maim && level >= 50)
-                            return WAR.StormsEye;
-                    }
-
-                    return WAR.HeavySwing;
-                }
-
-            // Replace Mythril Tempest with Mythril Tempest combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorMythrilTempestCombo))
-                if (actionID == WAR.MythrilTempest)
-                {
-                    if (comboTime > 0)
-                        if (lastMove == WAR.Overpower && level >= 40)
-                            return WAR.MythrilTempest;
-                    return WAR.Overpower;
-                }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorIRCombo))
-                if (actionID == WAR.InnerRelease || actionID == WAR.Berserk)
-                {
-                    if (SearchBuffArray(WAR.BuffPrimalRendReady))
-                        return WAR.PrimalRend;
-                    return iconHook.Original(self, actionID);
-                }
-
-            // SAMURAI
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiTsubameCombo))
-                if (actionID == SAM.Iaijutsu)
-                {
-                    var x = iconHook.Original(self, SAM.Tsubame);
-                    if (x != SAM.Tsubame) return x;
-                    return iconHook.Original(self, actionID);
-                }
-
-            // Replace Yukikaze with Yukikaze combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiYukikazeCombo))
-                if (actionID == SAM.Yukikaze)
-                {
-                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
-                        return SAM.Yukikaze;
-                    if (comboTime > 0)
-                        if (lastMove == SAM.Hakaze && level >= 50)
-                            return SAM.Yukikaze;
-                    return SAM.Hakaze;
-                }
-
-            // Replace Gekko with Gekko combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiGekkoCombo))
-                if (actionID == SAM.Gekko)
-                {
-                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
-                        return SAM.Gekko;
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == SAM.Hakaze && level >= 4)
-                            return SAM.Jinpu;
-                        if (lastMove == SAM.Jinpu && level >= 30)
-                            return SAM.Gekko;
-                    }
-
-                    return SAM.Hakaze;
-                }
-
-            // Replace Kasha with Kasha combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiKashaCombo))
-                if (actionID == SAM.Kasha)
-                {
-                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
-                        return SAM.Kasha;
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == SAM.Hakaze && level >= 18)
-                            return SAM.Shifu;
-                        if (lastMove == SAM.Shifu && level >= 40)
-                            return SAM.Kasha;
-                    }
-
-                    return SAM.Hakaze;
-                }
-
-            // Replace Mangetsu with Mangetsu combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiMangetsuCombo))
-                if (actionID == SAM.Mangetsu)
-                {
-                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
-                        return SAM.Mangetsu;
-                    if (comboTime > 0)
-                        if ((lastMove == SAM.Fuga || lastMove == SAM.Fuko) && level >= 35)
-                            return SAM.Mangetsu;
-                    if (level >= 86)
-                        return SAM.Fuko;
-                    return SAM.Fuga;
-                }
-
-            // Replace Oka with Oka combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiOkaCombo))
-                if (actionID == SAM.Oka)
-                {
-                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
-                        return SAM.Oka;
-                    if (comboTime > 0)
-                        if ((lastMove == SAM.Fuga || lastMove == SAM.Fuko) && level >= 45)
-                            return SAM.Oka;
-                    if (level >= 86)
-                        return SAM.Fuko;
-                    return SAM.Fuga;
-                }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiOgiCombo))
-                if (actionID == SAM.Ikishoten)
-                {
-                    if (SearchBuffArray(SAM.BuffOgiNamikiriReady))
-                        return SAM.OgiNamikiri;
-                    if (XIVComboPlugin.JobGauges.Get<SAMGauge>().Kaeshi == Kaeshi.NAMIKIRI)
-                        return SAM.KaeshiNamikiri;
-                        
-                    return SAM.Ikishoten;
-                }
-
-            // NINJA
-
-            // Replace Armor Crush with Armor Crush combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaArmorCrushCombo))
-                if (actionID == NIN.ArmorCrush)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == NIN.SpinningEdge && level >= 4)
-                            return NIN.GustSlash;
-                        if (lastMove == NIN.GustSlash && level >= 54)
-                            return NIN.ArmorCrush;
-                    }
-
-                    return NIN.SpinningEdge;
-                }
-
-            // Replace Aeolian Edge with Aeolian Edge combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAeolianEdgeCombo))
-                if (actionID == NIN.AeolianEdge)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == NIN.SpinningEdge && level >= 4)
-                            return NIN.GustSlash;
-                        if (lastMove == NIN.GustSlash && level >= 26)
-                            return NIN.AeolianEdge;
-                    }
-
-                    return NIN.SpinningEdge;
-                }
-
-            // Replace Hakke Mujinsatsu with Hakke Mujinsatsu combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaHakkeMujinsatsuCombo))
-                if (actionID == NIN.HakkeM)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == NIN.DeathBlossom && level >= 52)
-                            return NIN.HakkeM;
-                    }
-                    return NIN.DeathBlossom;
-                }
-
-            // GUNBREAKER
-
-            // Replace Solid Barrel with Solid Barrel combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerSolidBarrelCombo))
-                if (actionID == GNB.SolidBarrel)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == GNB.KeenEdge && level >= 4)
-                            return GNB.BrutalShell;
-                        if (lastMove == GNB.BrutalShell && level >= 26)
-                            return GNB.SolidBarrel;
-                    }
-                    return GNB.KeenEdge;
-                }
-
-            // Replace Wicked Talon with Gnashing Fang combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerGnashingFangCont))
-                if (actionID == GNB.GnashingFang)
-                {
-                    if (level >= GNB.LevelContinuation)
-                    {
-                        if (SearchBuffArray(GNB.BuffReadyToRip))
-                            return GNB.JugularRip;
-                        if (SearchBuffArray(GNB.BuffReadyToTear))
-                            return GNB.AbdomenTear;
-                        if (SearchBuffArray(GNB.BuffReadyToGouge))
-                            return GNB.EyeGouge;
-                    }
-                    return iconHook.Original(self, GNB.GnashingFang);
-                }
-
-            // Replace Burst Strike with Continuation
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerBurstStrikeCont))
-                if (actionID == GNB.BurstStrike)
-                {
-                    if (level >= GNB.LevelEnhancedContinuation)
-                    {
-                        if (SearchBuffArray(GNB.BuffReadyToBlast))
-                            return GNB.Hypervelocity;
-                    }
-                    return GNB.BurstStrike;
-                }
-
-            // Replace Demon Slaughter with Demon Slaughter combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerDemonSlaughterCombo))
-                if (actionID == GNB.DemonSlaughter)
-                {
-                    if (comboTime > 0)
-                        if (lastMove == GNB.DemonSlice && level >= 40)
-                            return GNB.DemonSlaughter;
-                    return GNB.DemonSlice;
-                }
-
-            // MACHINIST
-
-            // Replace Clean Shot with Heated Clean Shot combo
-            // Or with Heat Blast when overheated.
-            // For some reason the shots use their unheated IDs as combo moves
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistMainCombo))
-                if (actionID == MCH.CleanShot || actionID == MCH.HeatedCleanShot)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == MCH.SplitShot)
-                        {
-                            if (level >= 60)
-                                return MCH.HeatedSlugshot;
-                            if (level >= 2)
-                                return MCH.SlugShot;
-                        }
-
-                        if (lastMove == MCH.SlugShot)
-                        {
-                            if (level >= 64)
-                                return MCH.HeatedCleanShot;
-                            if (level >= 26)
-                                return MCH.CleanShot;
-                        }
-                    }
-
-                    if (level >= 54)
-                        return MCH.HeatedSplitShot;
-                    return MCH.SplitShot;
-                }
-
-
-            // Replace Hypercharge with Heat Blast when overheated
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistOverheatFeature))
-                if (actionID == MCH.Hypercharge)
-                {
-                    var gauge = XIVComboPlugin.JobGauges.Get<MCHGauge>();
-                    if (gauge.IsOverheated && level >= 35)
-                        return MCH.HeatBlast;
-                    return MCH.Hypercharge;
-                }
-
-            // Replace Spread Shot with Auto Crossbow when overheated.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistSpreadShotFeature))
-                if (actionID == MCH.SpreadShot || actionID == MCH.Scattergun)
-                {
-                    if (XIVComboPlugin.JobGauges.Get<MCHGauge>().IsOverheated && level >= 52)
-                        return MCH.AutoCrossbow;
-                    if (level >= 82)
-                        return MCH.Scattergun;
-                    return MCH.SpreadShot;
-                }
-
-            // BLACK MAGE
-
-            // B4 and F4 change to each other depending on stance, as do Flare and Freeze.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackEnochianFeature))
-            {
-                if (actionID == BLM.Fire4 || actionID == BLM.Blizzard4)
-                {
-                    var gauge = XIVComboPlugin.JobGauges.Get<BLMGauge>();
-                    if (gauge.InUmbralIce && level >= 58)
-                        return BLM.Blizzard4;
-                    if (level >= 60)
-                        return BLM.Fire4;
-                }
-
-                if (actionID == BLM.Flare || actionID == BLM.Freeze)
-                {
-                    var gauge = XIVComboPlugin.JobGauges.Get<BLMGauge>();
-                    if (gauge.InAstralFire && level >= 50)
-                        return BLM.Flare;
-                    return BLM.Freeze;
-                }
-            }
-
-            // Ley Lines and BTL
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
-                if (actionID == BLM.LeyLines)
-                {
-                    if (SearchBuffArray(BLM.BuffLeyLines) && level >= 62)
-                        return BLM.BTL;
-                    return BLM.LeyLines;
-                }
-
-            // ASTROLOGIAN
-
-            // Make cards on the same button as play
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.AstrologianCardsOnDrawFeature))
-                if (actionID == AST.Play)
-                {
-                    var gauge = XIVComboPlugin.JobGauges.Get<ASTGauge>();
-                    switch (gauge.DrawnCard)
-                    {
-                        case CardType.BALANCE:
-                            return AST.Balance;
-                        case CardType.BOLE:
-                            return AST.Bole;
-                        case CardType.ARROW:
-                            return AST.Arrow;
-                        case CardType.SPEAR:
-                            return AST.Spear;
-                        case CardType.EWER:
-                            return AST.Ewer;
-                        case CardType.SPIRE:
-                            return AST.Spire;
-                        default:
-                            return AST.Draw;
-                    }
-                }
-
-            // SUMMONER
-            // Change Fester into Energy Drain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerEDFesterCombo))
-                if (actionID == SMN.Fester)
-                {
-                    if (!XIVComboPlugin.JobGauges.Get<SMNGauge>().HasAetherflowStacks)
-                        return SMN.EnergyDrain;
-                    return SMN.Fester;
-                }
-
-            //Change Painflare into Energy Syphon
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerESPainflareCombo))
-                if (actionID == SMN.Painflare)
-                {
-                    if (!XIVComboPlugin.JobGauges.Get<SMNGauge>().HasAetherflowStacks)
-                        return SMN.EnergySyphon;
-                    return SMN.Painflare;
-                }
-
-            // SCHOLAR
-
-            // Change Fey Blessing into Consolation when Seraph is out.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
-                if (actionID == SCH.FeyBless)
-                {
-                    if (XIVComboPlugin.JobGauges.Get<SCHGauge>().SeraphTimer > 0) return SCH.Consolation;
-                    return SCH.FeyBless;
-                }
-
-            // Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarEnergyDrainFeature))
-                if (actionID == SCH.EnergyDrain)
-                {
-                    if (XIVComboPlugin.JobGauges.Get<SCHGauge>().Aetherflow == 0) return SCH.Aetherflow;
-                    return SCH.EnergyDrain;
-                }
-
-            // DANCER
-
-            // AoE GCDs are split into two buttons, because priority matters
-            // differently in different single-target moments. Thanks yoship.
-            // Replaces each GCD with its procced version.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerAoeGcdFeature))
-            {
-                if (actionID == DNC.Bloodshower)
-                {
-                    if (SearchBuffArray(DNC.BuffFlourishingFlow) || SearchBuffArray(DNC.BuffSilkenFlow))
-                        return DNC.Bloodshower;
-                    return DNC.Bladeshower;
-                }
-
-                if (actionID == DNC.RisingWindmill)
-                {
-                    if (SearchBuffArray(DNC.BuffFlourishingSymmetry) || SearchBuffArray(DNC.BuffSilkenSymmetry))
-                        return DNC.RisingWindmill;
-                    return DNC.Windmill;
-                }
-            }
-
-            // Fan Dance changes into Fan Dance 3 while flourishing.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerFanDanceCombo))
-            {
-                if (actionID == DNC.FanDance1)
-                {
-                    if (SearchBuffArray(DNC.BuffThreefoldFanDance))
-                        return DNC.FanDance3;
-                    return DNC.FanDance1;
-                }
-
-                // Fan Dance 2 changes into Fan Dance 3 while flourishing.
-                if (actionID == DNC.FanDance2)
-                {
-                    if (SearchBuffArray(DNC.BuffThreefoldFanDance))
-                        return DNC.FanDance3;
-                    return DNC.FanDance2;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerFanDance4Combo))
-            {
-                if (actionID == DNC.Flourish)
-                {
-                    if (SearchBuffArray(DNC.BuffFourfoldFanDance))
-                        return DNC.FanDance4;
-                    return DNC.Flourish;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerDevilmentCombo))
-            {
-                if (actionID == DNC.Devilment)
-                {
-                    if (SearchBuffArray(DNC.BuffStarfallDanceReady))
-                        return DNC.StarfallDance;
-                    return DNC.Devilment;
-                }
-            }
-
-            // WHM
-
-            // Replace Solace with Misery when full blood lily
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WhiteMageSolaceMiseryFeature))
-                if (actionID == WHM.Solace)
-                {
-                    if (XIVComboPlugin.JobGauges.Get<WHMGauge>().BloodLily == 3)
-                        return WHM.Misery;
-                    return WHM.Solace;
-                }
-
-            // Replace Solace with Misery when full blood lily
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WhiteMageRaptureMiseryFeature))
-                if (actionID == WHM.Rapture)
-                {
-                    if (XIVComboPlugin.JobGauges.Get<WHMGauge>().BloodLily == 3)
-                        return WHM.Misery;
-                    return WHM.Rapture;
-                }
-
-            // BARD
-
-            // Replace HS/BS with SS/RA when procced.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardStraightShotUpgradeFeature))
-                if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
-                {
-                    if (SearchBuffArray(BRD.BuffStraightShotReady))
-                    {
-                        if (level >= 70) return BRD.RefulgentArrow;
-                        return BRD.StraightShot;
-                    }
-
-                    if (level >= 76) return BRD.BurstShot;
-                    return BRD.HeavyShot;
-                }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardAoEUpgradeFeature))
-                if (actionID == BRD.QuickNock || actionID == BRD.Ladonsbite)
-                {
-                    if (SearchBuffArray(BRD.BuffShadowbiteReady))
-                    {
-                        return BRD.Shadowbite;
-                    }
-
-                    return iconHook.Original(self, BRD.QuickNock);
-                }
-
-            // MONK
-            // haha you get nothing now
-
-            // RED MAGE
-
-            // Replace Veraero/thunder 2 with Impact when Dualcast is active
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageAoECombo))
-            {
-                if (actionID == RDM.Veraero2)
-                {
-                    if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) || 
-                        SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
-                    {
-                        if (level >= 66) return RDM.Impact;
-                        return RDM.Scatter;
-                    }
-                    return iconHook.Original(self, RDM.Veraero2);
-                }
-
-                if (actionID == RDM.Verthunder2)
-                {
-                    if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) ||
-                        SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
-                    {
-                        if (level >= 66) return RDM.Impact;
-                        return RDM.Scatter;
-                    }
-                    return iconHook.Original(self, RDM.Verthunder2);
-                }
-            }
-
-            // Replace Redoublement with Redoublement combo, Enchanted if possible.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageMeleeCombo))
-                if (actionID == RDM.Redoublement)
-                {
-                    var gauge = XIVComboPlugin.JobGauges.Get<RDMGauge>();
-                    if ((lastMove == RDM.Riposte || lastMove == RDM.ERiposte) && level >= 35)
-                    {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
-                            return RDM.EZwerchhau;
-                        return RDM.Zwerchhau;
-                    }
-
-                    if (lastMove == RDM.Zwerchhau && level >= 50)
-                    {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
-                            return RDM.ERedoublement;
-                        return RDM.Redoublement;
-                    }
-
-                    if (gauge.BlackMana >= 20 && gauge.WhiteMana >= 20)
-                        return RDM.ERiposte;
-                    return RDM.Riposte;
-                }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageVerprocCombo))
-            {
-                if (actionID == RDM.Verstone)
-                {
-                    if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
-                    if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
-
-                    if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
-                    if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
-                }
-                if (actionID == RDM.Verfire)
-                {
-                    if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
-                    if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
-
-                    if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
-                    if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
-                }
-            }
-
-            // REAPER 
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperSliceCombo))
-            {
-                if (actionID == RPR.Slice)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == RPR.Slice && level >= RPR.Levels.WaxingSlice)
-                            return RPR.WaxingSlice;
-
-                        if (lastMove == RPR.WaxingSlice && level >= RPR.Levels.InfernalSlice)
-                            return RPR.InfernalSlice;
-                    }
-                    return RPR.Slice;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperScytheCombo))
-            {
-                if (actionID == RPR.SpinningScythe)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastMove == RPR.SpinningScythe && level >= RPR.Levels.NightmareScythe)
-                            return RPR.NightmareScythe;
-                    }
-
-                    return RPR.SpinningScythe;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperRegressFeature))
-            {
-                if (actionID == RPR.Egress || actionID == RPR.Ingress)
-                {
-                    if (SearchBuffArray(RPR.Buffs.Threshold)) return RPR.Regress;
-                    return actionID;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperEnshroudCombo))
-            {
-                if (actionID == RPR.Enshroud)
-                {
-                    if (SearchBuffArray(RPR.Buffs.Enshrouded)) return RPR.Communio;
-                    return actionID;
-                }
-            }
-
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperArcaneFeature))
-            {
-                if (actionID == RPR.ArcaneCircle)
-                {
-                    if (SearchBuffArray(RPR.Buffs.ImSac1) ||
-                        SearchBuffArray(RPR.Buffs.ImSac2))
-                        return RPR.PlentifulHarvest;
-                    return actionID;
-                }
-            }
-
-            return iconHook.Original(self, actionID);
-        }
-
-        private bool SearchBuffArray(ushort needle)
-        {
-            if (needle == 0) return false;
-            var buffs = clientState.LocalPlayer.StatusList;
-            for (var i = 0; i < buffs.Length; i++)
-                if (buffs[i].StatusId == needle)
-                    return true;
-            return false;
-        }        
-    }
+	public class IconReplacer
+	{
+		public delegate ulong OnCheckIsIconReplaceableDelegate(uint actionID);
+
+		public delegate ulong OnGetIconDelegate(byte param1, uint param2);
+
+		private readonly IconReplacerAddressResolver Address;
+		private readonly Hook<OnCheckIsIconReplaceableDelegate> checkerHook;
+		private readonly ClientState clientState;
+
+		private readonly IntPtr comboTimer;
+
+		private readonly XIVComboConfiguration Configuration;
+
+		private readonly Hook<OnGetIconDelegate> iconHook;
+		private readonly IntPtr lastComboMove;
+
+		private unsafe delegate int* getArray(long* address);
+
+		private Dictionary<string, Job> jobsMap;
+
+		public IconReplacer(SigScanner scanner, ClientState clientState, DataManager manager, XIVComboConfiguration configuration)
+		{
+
+			Configuration = configuration;
+			this.clientState = clientState;
+
+			Address = new IconReplacerAddressResolver();
+			Address.Setup(scanner);
+
+			comboTimer = Address.ComboTimer;
+			lastComboMove = comboTimer + 0x4;
+
+			PluginLog.Verbose("===== X I V C O M B O =====");
+			PluginLog.Verbose("IsIconReplaceable address {IsIconReplaceable}", Address.IsIconReplaceable);
+			PluginLog.Verbose("GetIcon address {GetIcon}", Address.GetIcon);
+			PluginLog.Verbose("ComboTimer address {ComboTimer}", comboTimer);
+			PluginLog.Verbose("LastComboMove address {LastComboMove}", lastComboMove);
+
+			iconHook = Hook<OnGetIconDelegate>.FromAddress(Address.GetIcon, GetIconDetour);
+			checkerHook = Hook<OnCheckIsIconReplaceableDelegate>.FromAddress(Address.IsIconReplaceable, CheckIsIconReplaceableDetour);
+
+			jobsMap = Job.Initialize(clientState, Configuration, iconHook);
+			
+			/*
+			jobsMap["DRG"] = new DRG();
+			jobsMap["DRK"] = new DRK();
+			jobsMap["PLD"] = new PLD();
+			jobsMap["WAR"] = new WAR();
+			jobsMap["SAM"] = new SAM();
+			jobsMap["NIN"] = new NIN();
+			jobsMap["GNB"] = new GNB();
+			jobsMap["MCH"] = new MCH();
+			jobsMap["BLM"] = new BLM();
+			jobsMap["AST"] = new AST();
+			jobsMap["SMN"] = new SMN();
+			jobsMap["SCH"] = new SCH();
+			jobsMap["DNC"] = new DNC();
+			jobsMap["WHM"] = new WHM();
+			jobsMap["BRD"] = new BRD();
+			jobsMap["RDM"] = new RDM();
+			jobsMap["RPR"] = new RPR();
+			*/
+		}
+
+		public void Enable()
+		{
+			iconHook.Enable();
+			checkerHook.Enable();
+		}
+
+		public void Dispose()
+		{
+			iconHook.Dispose();
+			checkerHook.Dispose();
+
+		}
+
+		// I hate this function. This is the dumbest function to exist in the game. Just return 1.
+		// Determines which abilities are allowed to have their icons updated.
+		private ulong CheckIsIconReplaceableDetour(uint actionID)
+		{
+			return 1;
+		}
+
+		/// <summary>
+		///     Replace an ability with another ability
+		///     actionID is the original ability to be "used"
+		///     Return either actionID (itself) or a new Action table ID as the
+		///     ability to take its place.
+		///     I tend to make the "combo chain" button be the last move in the combo
+		///     For example, Souleater combo on DRK happens by dragging Souleater
+		///     onto your bar and mashing it.
+		/// </summary>
+		private ulong GetIconDetour(byte self, uint actionID)
+		{
+			if (clientState.LocalPlayer != null)
+			{
+				var lastMove = Marshal.ReadInt32(lastComboMove);
+				var comboTime = Marshal.PtrToStructure<float>(comboTimer);
+				var level = clientState.LocalPlayer.Level;
+				var classAbbreviation = clientState.LocalPlayer.ClassJob.GameData.Abbreviation;
+
+				if (jobsMap.ContainsKey(classAbbreviation) && jobsMap[classAbbreviation].ReplaceIcon(self, level, lastMove, comboTime, actionID, out uint newActionID))
+					return iconHook.Original(self, newActionID);
+			}
+			
+			return iconHook.Original(self, actionID);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/AST.cs
+++ b/XIVComboPlugin/JobActions/AST.cs
@@ -1,20 +1,37 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
+using System.Collections.Generic;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class AST
-    {
-        public const uint
-            Play = 17055,
-            Draw = 3590,
-            Balance = 4401,
-            Bole = 4404,
-            Arrow = 4402,
-            Spear = 4403,
-            Ewer = 4405,
-            Spire = 4406,
-            MinorArcana = 7443,
-            CrownPlay = 25869;
-        public const ushort
-            BuffLordOfCrownsDrawn = 2054,
-            BuffLadyOfCrownsDrawn = 2055;
-    }
+	[Job("AST")]
+	public class AST : Job
+	{
+		private static JobAction
+			Play		= new JobAction(17055),
+			Draw		= new JobAction(3590),
+			Balance		= new JobAction(4401),
+			Bole		= new JobAction(4404),
+			Arrow		= new JobAction(4402),
+			Spear		= new JobAction(4403),
+			Ewer		= new JobAction(4405),
+			Spire		= new JobAction(4406),
+			MinorArcana	= new JobAction(7443),
+			CrownPlay	= new JobAction(25869);
+		private const ushort
+			BuffLordOfCrownsDrawn = 2054,
+			BuffLadyOfCrownsDrawn = 2055;
+	
+		public AST() : base()
+		{
+			ASTGauge gauge = XIVComboPlugin.JobGauges.Get<ASTGauge>();
+
+			Draw.SetCondition(() => gauge.DrawnCard == CardType.NONE);
+
+			// Make cards on the same button as play
+			ForFlag(CustomComboPreset.AstrologianCardsOnDrawFeature)
+				.UpgradeAction(Play, Draw);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/AST.cs
+++ b/XIVComboPlugin/JobActions/AST.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using System.Collections.Generic;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/BLM.cs
+++ b/XIVComboPlugin/JobActions/BLM.cs
@@ -1,18 +1,41 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class BLM
-    {
-        public const uint
-            Blizzard4 = 3576,
-            Fire4 = 3577,
-            Transpose = 149,
-            UmbralSoul = 16506,
-            LeyLines = 3573,
-            BTL = 7419,
-            Flare = 162,
-            Freeze = 159;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
 
-        public const ushort
-            BuffLeyLines = 737;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("BLM")]
+	public class BLM : Job
+	{
+		private static JobAction
+			Blizzard4	= new JobAction(3576,	58),
+			Fire4		= new JobAction(3577,	60),
+			Transpose	= new JobAction(149),
+			UmbralSoul	= new JobAction(16506),
+			LeyLines	= new JobAction(3573),
+			BTL			= new JobAction(7419,	62),
+			Flare		= new JobAction(162,	50),
+			Freeze		= new JobAction(159);
+
+		private const ushort
+			BuffLeyLines = 737;
+	
+		public BLM() : base()
+		{
+			BLMGauge gauge = XIVComboPlugin.JobGauges.Get<BLMGauge>();
+
+			Blizzard4.SetCondition(() => gauge.InUmbralIce);
+			Flare.SetCondition(() => gauge.InAstralFire);
+			BTL.SetCondition(() => HasBuff(BuffLeyLines));
+
+			// B4 and F4 change to each other depending on stance, as do Flare and Freeze.
+			ForFlag(CustomComboPreset.BlackEnochianFeature)
+				.ForAction(() => GetBestAvailableAction(Fire4, Blizzard4), Fire4, Blizzard4)
+				.ForAction(() => GetBestAvailableAction(Freeze, Flare), Freeze, Flare);
+
+			// Ley Lines and BTL
+			ForFlag(CustomComboPreset.BlackLeyLines)
+				.UpgradeAction(LeyLines, BTL);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/BLM.cs
+++ b/XIVComboPlugin/JobActions/BLM.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using Lumina.Excel.GeneratedSheets;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/BRD.cs
+++ b/XIVComboPlugin/JobActions/BRD.cs
@@ -1,20 +1,42 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class BRD
-    {
-        public const uint
-            WanderersMinuet = 3559,
-            PitchPerfect = 7404,
-            HeavyShot = 97,
-            BurstShot = 16495,
-            StraightShot = 98,
-            RefulgentArrow = 7409,
-            QuickNock = 106,
-            Ladonsbite = 25783,
-            Shadowbite = 16494;
+﻿using XIVCombo.JobActions;
 
-        public const ushort
-            BuffStraightShotReady = 122,
-            BuffShadowbiteReady = 3002;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("BRD")]
+	public class BRD : Job
+	{
+		private static JobAction
+			WanderersMinuet = new JobAction(3559),
+			PitchPerfect	= new JobAction(7404),
+			HeavyShot		= new JobAction(97),
+			BurstShot		= new JobAction(16495,	76),
+			StraightShot	= new JobAction(98),
+			RefulgentArrow	= new JobAction(7409,	70),
+			QuickNock		= new JobAction(106),
+			Ladonsbite		= new JobAction(25783),
+			Shadowbite		= new JobAction(16494);
+
+		private const ushort
+			BuffStraightShotReady = 122,
+			BuffShadowbiteReady = 3002;
+
+		public BRD() : base()
+		{
+			StraightShot.SetCondition(() => HasBuff(BuffStraightShotReady));
+			RefulgentArrow.SetCondition(() => CanUse(StraightShot));
+			Shadowbite.SetCondition(() => HasBuff(BuffShadowbiteReady));
+			// Replace HS/BS with SS/RA when procced.
+			ForFlag(CustomComboPreset.BardStraightShotUpgradeFeature)
+				.ForAction(
+					() => GetBestAvailableAction(HeavyShot, BurstShot, StraightShot, RefulgentArrow),
+					HeavyShot, BurstShot
+				);
+
+			ForFlag(CustomComboPreset.BardAoEUpgradeFeature)
+				.ForAction(
+					() => GetBestAvailableAction(QuickNock, Shadowbite),
+					QuickNock, Ladonsbite
+				);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/BRD.cs
+++ b/XIVComboPlugin/JobActions/BRD.cs
@@ -2,7 +2,7 @@
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("BRD")]
+	[Job("BRD", "ARC")]
 	public class BRD : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/DNC.cs
+++ b/XIVComboPlugin/JobActions/DNC.cs
@@ -1,26 +1,56 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class DNC
-    {
-        public const uint
-            Bladeshower = 15994,
-            Bloodshower = 15996,
-            Windmill = 15993,
-            RisingWindmill = 15995,
-            FanDance1 = 16007,
-            FanDance2 = 16008,
-            FanDance3 = 16009,
-            FanDance4 = 25791,
-            Flourish = 16013,
-            Devilment = 16011,
-            StarfallDance = 25792;
-        public const ushort
-            BuffFlourishingSymmetry = 3017,
-            BuffFlourishingFlow = 3018,
-            BuffThreefoldFanDance = 1820,
-            BuffFourfoldFanDance = 2699,
-            BuffStarfallDanceReady = 2700,
-            BuffSilkenSymmetry = 2693,
-            BuffSilkenFlow = 2694;
-    }
+	[Job("DNC")]
+	public class DNC : Job
+	{
+		private static JobAction
+			Bladeshower		= new JobAction(15994),
+			Bloodshower		= new JobAction(15996),
+			Windmill		= new JobAction(15993),
+			RisingWindmill	= new JobAction(15995),
+			FanDance1		= new JobAction(16007),
+			FanDance2		= new JobAction(16008),
+			FanDance3		= new JobAction(16009),
+			FanDance4		= new JobAction(25791),
+			Flourish		= new JobAction(16013),
+			Devilment		= new JobAction(16011),
+			StarfallDance	= new JobAction(25792);
+		private const ushort
+			BuffFlourishingSymmetry = 3017,
+			BuffFlourishingFlow = 3018,
+			BuffThreefoldFanDance = 1820,
+			BuffFourfoldFanDance = 2699,
+			BuffStarfallDanceReady = 2700,
+			BuffSilkenSymmetry = 2693,
+			BuffSilkenFlow = 2694;
+	
+		public DNC() : base()
+		{
+			Bloodshower.SetCondition(() => HasBuff(BuffFlourishingFlow, BuffSilkenFlow));
+			RisingWindmill.SetCondition(() => HasBuff(BuffFlourishingSymmetry, BuffSilkenSymmetry));
+			FanDance3.SetCondition(() => HasBuff(BuffThreefoldFanDance));
+			FanDance4.SetCondition(() => HasBuff(BuffFourfoldFanDance));
+			StarfallDance.SetCondition(() => HasBuff(BuffStarfallDanceReady));
+
+			// AoE GCDs are split into two buttons, because priority matters
+			// differently in different single-target moments. Thanks yoship.
+			// Replaces each GCD with its procced version.
+			ForFlag(CustomComboPreset.DancerAoeGcdFeature)
+				.ForComboActions(Bladeshower, Bloodshower)
+				.ForComboActions(Windmill, RisingWindmill);
+
+			// Fan Dance changes into Fan Dance 3 while flourishing.
+			ForFlag(CustomComboPreset.DancerFanDanceCombo)
+				.UpgradeAction(FanDance1, FanDance3)
+				.UpgradeAction(FanDance2, FanDance3);
+
+			ForFlag(CustomComboPreset.DancerFanDance4Combo)
+				.UpgradeAction(Flourish, FanDance4);
+
+			ForFlag(CustomComboPreset.DancerDevilmentCombo)
+				.UpgradeAction(Devilment, StarfallDance);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -1,31 +1,76 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class DRG
-    {
-        public const uint
-            Jump = 92,
-            HighJump = 16478,
-            MirageDive = 7399,
-            BOTD = 3553,
-            Stardiver = 16480,
-            CTorment = 16477,
-            DoomSpike = 86,
-            SonicThrust = 7397,
-            ChaosThrust = 88,
-            RaidenThrust = 16479,
-            HeavensThrust = 25771,
-            ChaoticSpring = 25772,
-            DraconianFury = 25770,
-            TrueThrust = 75,
-            Disembowel = 87,
-            FangAndClaw = 3554,
-            WheelingThrust = 3556,
-            FullThrust = 84,
-            VorpalThrust = 78;
+﻿using XIVCombo.JobActions;
 
-        public const ushort
-            BuffFangAndClawReady = 802,
-            BuffWheelingThrustReady = 803,
-            BuffDraconianFire = 1863;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("DRG")]
+	public class DRG : Job
+	{
+		private static JobAction
+			Jump            = new JobAction(92),
+			HighJump        = new JobAction(16478),
+			MirageDive      = new JobAction(7399),
+			BOTD            = new JobAction(3553),
+			Stardiver       = new JobAction(16480),
+			CTorment        = new JobAction(16477,	72),
+			DoomSpike       = new JobAction(86),
+			SonicThrust     = new JobAction(7397,	62),
+			ChaosThrust     = new JobAction(88,		50),
+			RaidenThrust    = new JobAction(16479,	76),
+			HeavensThrust   = new JobAction(25771,	86),
+			ChaoticSpring   = new JobAction(25772,	86),
+			DraconianFury   = new JobAction(25770),
+			TrueThrust      = new JobAction(75),
+			Disembowel      = new JobAction(87,		18),
+			FangAndClaw     = new JobAction(3554,	56),
+			WheelingThrust  = new JobAction(3556,	58),
+			FullThrust      = new JobAction(84,		26),
+			VorpalThrust    = new JobAction(78,		4);
+
+		private const ushort
+			BuffFangAndClawReady = 802,
+			BuffWheelingThrustReady = 803,
+			BuffDraconianFire = 1863,
+			BuffDiveReady = 1243;
+
+		public DRG() : base()
+		{
+			MirageDive.SetCondition(() => HasBuff(BuffDiveReady));
+			SonicThrust.SetCondition(() => LastMoveWasInCombo(DoomSpike, DraconianFury));
+			CTorment.SetCondition(() => LastMoveWasInCombo(SonicThrust));
+			Disembowel.SetCondition(() => LastMoveWasInCombo(TrueThrust, RaidenThrust));
+			ChaosThrust.SetCondition(() => LastMoveWasInCombo(Disembowel));
+			ChaoticSpring.SetCondition(() => CanUse(ChaosThrust));
+			FangAndClaw.SetCondition(() => HasBuff(BuffFangAndClawReady));
+			WheelingThrust.SetCondition(() => HasBuff(BuffWheelingThrustReady));
+			RaidenThrust.SetCondition(() => HasBuff(BuffDraconianFire));
+			FullThrust.SetCondition(() => LastMoveWasInCombo(VorpalThrust));
+			HeavensThrust.SetCondition(() => CanUse(FullThrust));
+			VorpalThrust.SetCondition(() => LastMoveWasInCombo(TrueThrust, RaidenThrust));
+
+			// Change Jump/High Jump into Mirage Dive when Dive Ready
+			ForFlag(CustomComboPreset.DragoonJumpFeature)
+				.ForAction(
+					() => GetBestAvailableAction(currentAction, MirageDive),
+					Jump, HighJump
+				);
+
+			// Replace Coerthan Torment with Coerthan Torment combo chain
+			ForFlag(CustomComboPreset.DragoonCoerthanTormentCombo)
+				.ForComboActions(DoomSpike, SonicThrust, CTorment);
+
+			// Replace Chaos Thrust with the Chaos Thrust combo chain
+			ForFlag(CustomComboPreset.DragoonChaosThrustCombo)
+				.ForAction(
+					() => GetBestAvailableAction(TrueThrust, FangAndClaw, WheelingThrust, RaidenThrust, Disembowel, currentAction),
+					ChaosThrust, ChaoticSpring
+				);
+
+			// Replace Full Thrust with the Full Thrust combo chain
+			ForFlag(CustomComboPreset.DragoonFullThrustCombo)
+				.ForAction(
+					() => GetBestAvailableAction(TrueThrust, FangAndClaw, WheelingThrust, RaidenThrust, VorpalThrust, currentAction),
+					FullThrust, HeavensThrust
+				);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -2,7 +2,7 @@
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("DRG")]
+	[Job("DRG", "LNC")]
 	public class DRG : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/DRK.cs
+++ b/XIVComboPlugin/JobActions/DRK.cs
@@ -1,5 +1,4 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using XIVCombo.JobActions;
+﻿using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {

--- a/XIVComboPlugin/JobActions/DRK.cs
+++ b/XIVComboPlugin/JobActions/DRK.cs
@@ -1,12 +1,31 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class DRK
-    {
-        public const uint
-            Souleater = 3632,
-            HardSlash = 3617,
-            SyphonStrike = 3623,
-            StalwartSoul = 16468,
-            Unleash = 3621;
-    }
+	[Job("DRK")]
+	public class DRK : Job
+	{
+		private static JobAction
+			HardSlash		= new JobAction(3617),
+			SyphonStrike	= new JobAction(3623,	2),
+			Souleater		= new JobAction(3632,	26),
+			Unleash			= new JobAction(3621),
+			StalwartSoul	= new JobAction(16468,	40);
+
+		public DRK() : base()
+		{
+			SyphonStrike.SetCondition(() => LastMoveWasInCombo(HardSlash));
+			Souleater.SetCondition(() => LastMoveWasInCombo(SyphonStrike));
+			StalwartSoul.SetCondition(() => LastMoveWasInCombo(Unleash));
+
+			// Replace Souleater with Souleater combo chain
+			ForFlag(CustomComboPreset.DarkSouleaterCombo)
+				.ForComboActions(HardSlash, SyphonStrike, Souleater);
+
+			// Replace Stalwart Soul with Stalwart Soul combo chain
+			ForFlag(CustomComboPreset.DarkStalwartSoulCombo)
+				.ForComboActions(Unleash, StalwartSoul);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/GNB.cs
+++ b/XIVComboPlugin/JobActions/GNB.cs
@@ -1,5 +1,4 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using XIVCombo.JobActions;
+﻿using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {

--- a/XIVComboPlugin/JobActions/GNB.cs
+++ b/XIVComboPlugin/JobActions/GNB.cs
@@ -1,29 +1,57 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class GNB
-    {
-        public const uint
-            SolidBarrel = 16145,
-            KeenEdge = 16137,
-            BrutalShell = 16139,
-            WickedTalon = 16150,
-            GnashingFang = 16146,
-            SavageClaw = 16147,
-            DemonSlaughter = 16149,
-            DemonSlice = 16141,
-            Continuation = 16155,
-            JugularRip = 16156,
-            AbdomenTear = 16157,
-            EyeGouge = 16158,
-            BurstStrike = 16162,
-            Hypervelocity = 25759;
-        public const ushort
-            BuffReadyToRip = 1842,
-            BuffReadyToTear = 1843,
-            BuffReadyToGouge = 1844,
-            BuffReadyToBlast = 2686;
-        public const byte
-            LevelContinuation = 70,
-            LevelEnhancedContinuation = 86;
-    }
+	[Job("GNB")]
+	public class GNB : Job
+	{
+		private static JobAction
+			SolidBarrel		= new JobAction(16145,	26),
+			KeenEdge		= new JobAction(16137),
+			BrutalShell		= new JobAction(16139,	4),
+			WickedTalon		= new JobAction(16150),
+			GnashingFang	= new JobAction(16146),
+			SavageClaw		= new JobAction(16147),
+			DemonSlaughter	= new JobAction(16149,	40),
+			DemonSlice		= new JobAction(16141),
+			Continuation	= new JobAction(16155,	70),
+			JugularRip		= new JobAction(16156,	70),
+			AbdomenTear		= new JobAction(16157,	70),
+			EyeGouge		= new JobAction(16158,	70),
+			BurstStrike		= new JobAction(16162),
+			Hypervelocity	= new JobAction(25759,	86);
+		private const ushort
+			BuffReadyToRip = 1842,
+			BuffReadyToTear = 1843,
+			BuffReadyToGouge = 1844,
+			BuffReadyToBlast = 2686;
+	
+		public GNB() : base()
+		{
+			BrutalShell.SetCondition(() => LastMoveWasInCombo(KeenEdge));
+			SolidBarrel.SetCondition(() => LastMoveWasInCombo(BrutalShell));
+			JugularRip.SetCondition(() => HasBuff(BuffReadyToRip));
+			AbdomenTear.SetCondition(() => HasBuff(BuffReadyToTear));
+			EyeGouge.SetCondition(() => HasBuff(BuffReadyToGouge));
+			Hypervelocity.SetCondition(() => HasBuff(BuffReadyToBlast));
+			DemonSlaughter.SetCondition(() => LastMoveWasInCombo(DemonSlice));
+
+			// Replace Solid Barrel with Solid Barrel combo
+			ForFlag(CustomComboPreset.GunbreakerSolidBarrelCombo)
+				.ForComboActions(KeenEdge, BrutalShell, SolidBarrel);
+
+			// Replace Wicked Talon with Gnashing Fang combo
+			ForFlag(CustomComboPreset.GunbreakerGnashingFangCont)
+				.ForComboActions(JugularRip, AbdomenTear, EyeGouge, GnashingFang);
+
+			// Replace Burst Strike with Continuation
+			ForFlag(CustomComboPreset.GunbreakerBurstStrikeCont)
+				.UpgradeAction(BurstStrike, Hypervelocity);
+
+			// Replace Demon Slaughter with Demon Slaughter combo
+			ForFlag(CustomComboPreset.GunbreakerDemonSlaughterCombo)
+				.ForComboActions(DemonSlice, DemonSlaughter);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/Job.cs
+++ b/XIVComboPlugin/JobActions/Job.cs
@@ -1,7 +1,6 @@
 ﻿using Dalamud.Game.ClientState;
 using Dalamud.Hooking;
 using Dalamud.Logging;
-using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/XIVComboPlugin/JobActions/Job.cs
+++ b/XIVComboPlugin/JobActions/Job.cs
@@ -12,12 +12,12 @@ namespace XIVCombo.JobActions
 {
 	public class JobAttribute : Attribute
 	{
-		internal JobAttribute(string abbreviation)
+		internal JobAttribute(params string[] abbreviations)
 		{
-			Abbreviation = abbreviation;
+			Abbreviations = abbreviations;
 		}
 
-		public string Abbreviation { get; }
+		public string[] Abbreviations { get; }
 
 	}
 	public abstract class Job
@@ -41,9 +41,11 @@ namespace XIVCombo.JobActions
 			Dictionary<string, Job> jobs = new Dictionary<string, Job>();
 			foreach (Type jobType in jobTypes)
 			{
-				string abbreviation = jobType.GetCustomAttribute<JobAttribute>().Abbreviation;
-				PluginLog.Log($"{abbreviation} Loaded");
-				jobs[abbreviation] = (Job)Activator.CreateInstance(jobType);
+				PluginLog.Log($"{jobType.Name} Loaded");
+				string[] abbreviations = jobType.GetCustomAttribute<JobAttribute>().Abbreviations;
+				Job job = (Job)Activator.CreateInstance(jobType);
+				foreach(string abbreviation in abbreviations)
+					jobs[abbreviation] = job;
 			}
 			return jobs;
 		}

--- a/XIVComboPlugin/JobActions/Job.cs
+++ b/XIVComboPlugin/JobActions/Job.cs
@@ -1,0 +1,162 @@
+﻿using Dalamud.Game.ClientState;
+using Dalamud.Hooking;
+using Dalamud.Logging;
+using Lumina.Excel.GeneratedSheets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using XIVComboPlugin;
+using static XIVComboPlugin.IconReplacer;
+
+namespace XIVCombo.JobActions
+{
+	public class JobAttribute : Attribute
+	{
+		internal JobAttribute(string abbreviation)
+		{
+			Abbreviation = abbreviation;
+		}
+
+		public string Abbreviation { get; }
+
+	}
+	public abstract class Job
+	{
+		protected static ClientState clientState;
+		protected static XIVComboConfiguration Configuration;
+		protected static Hook<OnGetIconDelegate> iconHook;
+		private readonly JobConfig jobConfig;
+		public Job()
+		{
+			jobConfig = new JobConfig(this);
+		}
+
+		public static Dictionary<string, Job> Initialize(ClientState clientState, XIVComboConfiguration Configuration, Hook<OnGetIconDelegate> iconHook)
+		{
+			Job.clientState = clientState;
+			Job.Configuration = Configuration;
+			Job.iconHook = iconHook;
+
+			Type[] jobTypes = Assembly.GetExecutingAssembly().GetTypes().Where(type => type.IsDefined(typeof(JobAttribute))).ToArray();
+			Dictionary<string, Job> jobs = new Dictionary<string, Job>();
+			foreach (Type jobType in jobTypes)
+			{
+				string abbreviation = jobType.GetCustomAttribute<JobAttribute>().Abbreviation;
+				PluginLog.Log($"{abbreviation} Loaded");
+				jobs[abbreviation] = (Job)Activator.CreateInstance(jobType);
+			}
+			return jobs;
+		}
+
+		private byte self;
+		protected byte currentLevel { get; private set; }
+		protected JobAction currentAction { get; private set; }
+		private int lastMove;
+		private float comboTime;
+		public bool ReplaceIcon(byte self, byte currentLevel, int lastMove, float comboTime, uint currentActionID, out uint newActionID)
+		{
+			newActionID = currentAction = JobAction.FromId(currentActionID);
+			if (currentAction != null)
+			{
+				this.self = self;
+				this.currentLevel = currentLevel;
+				this.lastMove = lastMove;
+				this.comboTime = comboTime;
+
+				return ProcessActionLogic(out newActionID);
+			}
+
+			return false;
+		}
+
+		// The default logic using jobConfig is probably good enough for most classes, but it can be
+		// overridden if you don't want to use jobConfig and would rather write the logic manually
+		protected virtual bool ProcessActionLogic(out uint newActionID)
+		{
+			var actionLogic = jobConfig.GetActionLogic(Configuration);
+			if (actionLogic.ContainsKey(currentAction))
+			{
+				newActionID = actionLogic[currentAction]();
+				if (newActionID == 0)
+					newActionID = currentAction;
+				return true;
+			}
+			newActionID = currentAction;
+			return false;
+		}
+
+		// Pick the last option which is still usable.
+		// The actions should be listed in order of combo, level, and/or from most accessible to least accessible
+		protected JobAction GetBestAvailableAction(params JobAction[] actions)
+		{
+			return actions.Where(CanUse).LastOrDefault();
+		}
+		protected bool IsCurrentAction(params JobAction[] actions) => actions.Any(action => action.Id == currentAction);
+		protected bool CanUse(JobAction action) => action.Level <= currentLevel && action.ConditionPasses();
+		protected bool LastMoveWas(params JobAction[] actions) => actions.Any(action => action.Id == lastMove);
+		protected bool InCombo() => comboTime > 0;
+		protected bool LastMoveWasInCombo(params JobAction[] actions) => InCombo() && actions.Any(action => action.Id == lastMove);
+		protected bool HasBuff(params uint[] buffs)
+		{
+			buffs = buffs.Where(buff => buff > 0).ToArray();
+			if (buffs.Length > 0)
+				return clientState.LocalPlayer.StatusList.Any(status => buffs.Contains(status.StatusId));
+
+			return false;
+		}
+		protected JobAction Resolve(JobAction action) => JobAction.FromId((uint)iconHook.Original(self, action));
+		protected JobConfig.JobConfigData ForFlag(CustomComboPreset flag) => jobConfig.ForFlag(flag);
+
+		protected class JobConfig
+		{
+			private Job job;
+			internal JobConfig(Job job) => this.job = job;
+
+			private readonly Dictionary<CustomComboPreset, JobConfigData> configData = new Dictionary<CustomComboPreset, JobConfigData>();
+			public JobConfigData ForFlag(CustomComboPreset flag)
+			{
+				configData[flag] = new JobConfigData(job);
+				return configData[flag];
+			}
+
+			public delegate uint ActionLogic();
+			internal Dictionary<JobAction, ActionLogic> GetActionLogic(XIVComboConfiguration Configuration)
+			{
+				Dictionary<JobAction, ActionLogic> actionLogicMap = new Dictionary<JobAction, ActionLogic>();
+				foreach (CustomComboPreset flag in configData.Keys)
+				{
+					if (Configuration.ComboPresets.HasFlag(flag))
+						configData[flag].actionLogicMap.ToList().ForEach(x => actionLogicMap[x.Key] = x.Value);
+				}
+				return actionLogicMap;
+			}
+
+			public class JobConfigData
+			{
+				private Job job;
+				internal JobConfigData(Job job) => this.job = job;
+				internal readonly Dictionary<JobAction, ActionLogic> actionLogicMap = new Dictionary<JobAction, ActionLogic>();
+				public JobConfigData ForAction(ActionLogic logic, params JobAction[] actions)
+				{
+					foreach (JobAction action in actions)
+						actionLogicMap[action] = logic;
+					return this;
+				}
+				public JobConfigData ForComboActions(params JobAction[] actions)
+				{
+					if (actions.Length > 0)
+						ForAction(() => job.GetBestAvailableAction(actions), actions[actions.Length - 1]);
+					return this;
+				}
+
+				public JobConfigData UpgradeAction(params JobAction[] actions)
+				{
+					if (actions.Length > 0)
+						ForAction(() => job.GetBestAvailableAction(actions), actions[0]);
+					return this;
+				}
+			}
+		}
+	}
+}

--- a/XIVComboPlugin/JobActions/JobAction.cs
+++ b/XIVComboPlugin/JobActions/JobAction.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace XIVCombo.JobActions
+{
+	public class JobAction
+	{
+		private static Dictionary<uint, JobAction> map = new Dictionary<uint, JobAction>();
+		public static JobAction FromId(uint Id) => map.ContainsKey(Id) ? map[Id] : null;
+
+		public readonly uint Id;
+		public readonly byte Level;
+		private Func<bool> condition; 
+
+		public JobAction(uint Id, byte Level = 1)
+		{
+			this.Id = Id;
+			this.Level = Level;
+			map[Id] = this;
+		}
+		public void SetCondition(Func<bool> predicate) => (this.condition) = (predicate);
+		public bool ConditionPasses() => condition?.Invoke() ?? true;
+
+		public static implicit operator uint(JobAction action) => action?.Id ?? 0;
+		public static implicit operator byte(JobAction action) => action?.Level ?? 0;
+	}
+}

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -1,18 +1,50 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class MCH
-    {
-        public const uint
-            CleanShot = 2873,
-            HeatedCleanShot = 7413,
-            SplitShot = 2866,
-            HeatedSplitShot = 7411,
-            SlugShot = 2868,
-            HeatedSlugshot = 7412,
-            Hypercharge = 17209,
-            HeatBlast = 7410,
-            SpreadShot = 2870,
-            AutoCrossbow = 16497,
-            Scattergun = 25786;
-    }
+	[Job("MCH")]
+	public class MCH : Job
+	{
+		private static JobAction
+			CleanShot		= new JobAction(2873,	26),
+			HeatedCleanShot	= new JobAction(7413,	64),
+			SplitShot		= new JobAction(2866),
+			HeatedSplitShot	= new JobAction(7411,	54),
+			SlugShot		= new JobAction(2868,	2),
+			HeatedSlugshot	= new JobAction(7412,	60),
+			Hypercharge		= new JobAction(17209),
+			HeatBlast		= new JobAction(7410,	35),
+			SpreadShot		= new JobAction(2870),
+			AutoCrossbow	= new JobAction(16497,	52),
+			Scattergun		= new JobAction(25786,	82);
+	
+		public MCH() : base()
+		{
+			MCHGauge gauge = XIVComboPlugin.JobGauges.Get<MCHGauge>();
+
+			SlugShot.SetCondition(() => LastMoveWasInCombo(SplitShot));
+			HeatedSlugshot.SetCondition(() => CanUse(SlugShot));
+			CleanShot.SetCondition(() => LastMoveWasInCombo(SlugShot));
+			HeatedCleanShot.SetCondition(() => CanUse(CleanShot));
+			HeatBlast.SetCondition(() => gauge.IsOverheated);
+			AutoCrossbow.SetCondition(() => gauge.IsOverheated);
+
+			// Replace Clean Shot with Heated Clean Shot combo
+			// Or with Heat Blast when overheated.
+			// For some reason the shots use their unheated IDs as combo moves
+			ForFlag(CustomComboPreset.MachinistMainCombo)
+				.ForComboActions(HeatedSplitShot, HeatedSlugshot, HeatedCleanShot)
+				.ForComboActions(SplitShot, SlugShot, CleanShot);
+
+			// Replace Hypercharge with Heat Blast when overheated
+			ForFlag(CustomComboPreset.MachinistOverheatFeature)
+				.UpgradeAction(Hypercharge, HeatBlast);
+
+			// Replace Spread Shot with Auto Crossbow when overheated.
+			ForFlag(CustomComboPreset.MachinistSpreadShotFeature)
+				.ForAction(() => GetBestAvailableAction(SpreadShot, Scattergun, AutoCrossbow), SpreadShot, Scattergun);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using Lumina.Excel.GeneratedSheets;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/MNK.cs
+++ b/XIVComboPlugin/JobActions/MNK.cs
@@ -4,13 +4,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using XIVCombo.JobActions;
+
 namespace XIVComboPlugin.JobActions
 {
-    public static class MNK
-    {
-        public const uint
-            AOTD = 62,
-            FourPointFury = 16473,
-            Rockbreaker = 70;
-    }
+	public class MNK : Job
+	{
+		private static JobAction
+			AOTD			= new JobAction(62),
+			FourPointFury	= new JobAction(16473),
+			Rockbreaker		= new JobAction(70);
+	
+		public MNK() : base()
+		{
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -1,20 +1,44 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class NIN
-    {
-        public const uint
-            ArmorCrush = 3563,
-            SpinningEdge = 2240,
-            GustSlash = 2242,
-            AeolianEdge = 2255,
-            HakkeM = 16488,
-            DeathBlossom = 2254,
-            DWAD = 3566,
-            Assassinate = 2246,
-            Bunshin = 16493,
-            PhantomK = 25774;
+﻿using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
 
-        public const ushort
-            BuffPhantomKReady = 2723;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("NIN")]
+	public class NIN : Job
+	{
+		private static JobAction
+			ArmorCrush		= new JobAction(3563,	54),
+			SpinningEdge	= new JobAction(2240),
+			GustSlash		= new JobAction(2242,	4),
+			AeolianEdge		= new JobAction(2255,	26),
+			HakkeM			= new JobAction(16488,	52),
+			DeathBlossom	= new JobAction(2254),
+			DWAD			= new JobAction(3566),
+			Assassinate		= new JobAction(2246),
+			Bunshin		    = new JobAction(16493),
+			PhantomK		= new JobAction(25774);
+
+		private const ushort
+			BuffPhantomKReady = 2723;
+	
+		public NIN() : base()
+		{
+			GustSlash.SetCondition(() => LastMoveWasInCombo(SpinningEdge));
+			ArmorCrush.SetCondition(() => LastMoveWasInCombo(GustSlash));
+			AeolianEdge.SetCondition(() => LastMoveWasInCombo(GustSlash));
+			HakkeM.SetCondition(() => LastMoveWasInCombo(DeathBlossom));
+
+			// Replace Armor Crush with Armor Crush combo
+			ForFlag(CustomComboPreset.NinjaArmorCrushCombo)
+				.ForComboActions(SpinningEdge, GustSlash, ArmorCrush);
+
+			// Replace Aeolian Edge with Aeolian Edge combo
+			ForFlag(CustomComboPreset.NinjaAeolianEdgeCombo)
+				.ForComboActions(SpinningEdge, GustSlash, AeolianEdge);
+
+			// Replace Hakke Mujinsatsu with Hakke Mujinsatsu combo
+			ForFlag(CustomComboPreset.NinjaHakkeMujinsatsuCombo)
+				.ForComboActions(DeathBlossom, HakkeM);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -1,5 +1,4 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using XIVCombo.JobActions;
+﻿using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -2,7 +2,7 @@
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("NIN")]
+	[Job("NIN", "ROG")]
 	public class NIN : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -2,7 +2,7 @@
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("PLD")]
+	[Job("PLD", "GLA")]
 	public class PLD : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -1,5 +1,4 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using XIVCombo.JobActions;
+﻿using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -1,23 +1,62 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class PLD
-    {
-        public const uint
-            GoringBlade = 3538,
-            FastBlade = 9,
-            RiotBlade = 15,
-            RoyalAuthority = 3539,
-            RageOfHalone = 21,
-            Prominence = 16457,
-            TotalEclipse = 7381,
-            Requiescat = 7383,
-            Confiteor = 16459,
-            BladeOfFaith = 25748,
-            BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+﻿using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
 
-        public const ushort
-            BuffRequiescat = 1368,
-            BuffBladeOfFaithReady = 3019;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("PLD")]
+	public class PLD : Job
+	{
+		private static JobAction
+			FastBlade			= new JobAction(9),
+			RiotBlade			= new JobAction(15,		4),
+			GoringBlade			= new JobAction(3538,	54),
+			RageOfHalone		= new JobAction(21,		26),
+			RoyalAuthority		= new JobAction(3539,	60),
+			Prominence			= new JobAction(16457,	40),
+			TotalEclipse		= new JobAction(7381),
+			Requiescat			= new JobAction(7383),
+			Confiteor			= new JobAction(16459,	80),
+			BladeOfFaith		= new JobAction(25748),
+			BladeOfTruth		= new JobAction(25749),
+			BladeOfValor		= new JobAction(25750);
+
+		private const ushort
+			BuffRequiescat = 1368,
+			BuffBladeOfFaithReady = 3019;
+
+		public PLD() : base()
+		{
+			RiotBlade.SetCondition(() => LastMoveWasInCombo(FastBlade));
+			GoringBlade.SetCondition(() => LastMoveWasInCombo(RiotBlade));
+			RageOfHalone.SetCondition(() => LastMoveWasInCombo(RiotBlade));
+			RoyalAuthority.SetCondition(() => CanUse(RageOfHalone));
+			Prominence.SetCondition(() => LastMoveWasInCombo(TotalEclipse));
+			BladeOfFaith.SetCondition(() => HasBuff(BuffBladeOfFaithReady));
+			BladeOfTruth.SetCondition(() => LastMoveWasInCombo(BladeOfFaith));
+			BladeOfValor.SetCondition(() => LastMoveWasInCombo(BladeOfTruth));
+			Confiteor.SetCondition(() => HasBuff(BuffRequiescat));
+
+			// Replace Goring Blade with Goring Blade combo
+			ForFlag(CustomComboPreset.PaladinGoringBladeCombo)
+				.ForComboActions(FastBlade, RiotBlade, GoringBlade);
+
+			// Replace Royal Authority with Royal Authority combo
+			ForFlag(CustomComboPreset.PaladinRoyalAuthorityCombo)
+				.ForComboActions(FastBlade, RiotBlade, RageOfHalone)
+				.ForComboActions(FastBlade, RiotBlade, RoyalAuthority);
+			// Could also be written as:
+			//.ForAction(
+			//    () => GetBestAvailableAction(FastBlade, RiotBlade, currentAction),
+			//    RageOfHalone, RoyalAuthority
+			//);
+
+			// Replace Prominence with Prominence combo
+			ForFlag(CustomComboPreset.PaladinProminenceCombo)
+				.ForComboActions(TotalEclipse, Prominence);
+
+			// Replace Requiescat with Confiteor when under the effect of Requiescat
+			ForFlag(CustomComboPreset.PaladinRequiescatCombo)
+				.UpgradeAction(Requiescat, Confiteor, BladeOfFaith, BladeOfValor, BladeOfTruth);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -1,33 +1,75 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class RDM
-    {
-        public const uint
-            Veraero2 = 16525,
-            Verthunder2 = 16524,
-            Impact = 16526,
-            Redoublement = 7516,
-            ERedoublement = 7529,
-            Zwerchhau = 7512,
-            EZwerchhau = 7528,
-            Riposte = 7504,
-            ERiposte = 7527,
-            Scatter = 7509,
-            Verstone = 7511,
-            Verfire = 7510,
-            Jolt = 7503,
-            Jolt2 = 7524,
-            Verholy = 7526,
-            Verflare = 7525,
-            Scorch = 16530,
-            Resolution = 25858;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
 
-        public const ushort
-            BuffSwiftcast = 167,
-            BuffDualcast = 1249,
-            BuffAcceleration = 1238,
-            BuffChainspell = 2560,
-            BuffVerstoneReady = 1235,
-            BuffVerfireReady = 1234;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("RDM")]
+	public class RDM : Job
+	{
+		private static JobAction
+			Veraero2		= new JobAction(16525	),
+			Verthunder2		= new JobAction(16524	),
+			Impact			= new JobAction(16526,	66),
+			Redoublement	= new JobAction(7516,	50),
+			ERedoublement	= new JobAction(7529,	50),
+			Zwerchhau		= new JobAction(7512,	35),
+			EZwerchhau		= new JobAction(7528,	35),
+			Riposte			= new JobAction(7504	),
+			ERiposte		= new JobAction(7527	),
+			Scatter			= new JobAction(7509	),
+			Verstone		= new JobAction(7511	),
+			Verfire			= new JobAction(7510	),
+			Jolt			= new JobAction(7503	),
+			Jolt2			= new JobAction(7524,	62),
+			Verholy			= new JobAction(7526	),
+			Verflare		= new JobAction(7525	),
+			Scorch			= new JobAction(16530,	80),
+			Resolution		= new JobAction(25858,	90);
+
+		private const ushort
+			BuffSwiftcast = 167,
+			BuffDualcast = 1249,
+			BuffAcceleration = 1238,
+			BuffChainspell = 2560,
+			BuffVerstoneReady = 1235,
+			BuffVerfireReady = 1234;
+
+		private static RDMGauge gauge;
+		private static bool HasMana(byte manaMin) => gauge.BlackMana >= manaMin && gauge.WhiteMana >= manaMin;
+
+		public RDM() : base()
+		{
+			gauge = XIVComboPlugin.JobGauges.Get<RDMGauge>();
+			Verstone.SetCondition(() => IsCurrentAction(Verstone) && HasBuff(BuffVerstoneReady));
+			Verfire.SetCondition(() => IsCurrentAction(Verfire) && HasBuff(BuffVerfireReady));
+			ERiposte.SetCondition(() => HasMana(20));
+			Zwerchhau.SetCondition(() => LastMoveWas(Riposte, ERiposte));
+			EZwerchhau.SetCondition(() => CanUse(Zwerchhau) && HasMana(15));
+			Redoublement.SetCondition(() => LastMoveWas(Zwerchhau, EZwerchhau));
+			ERedoublement.SetCondition(() => CanUse(Redoublement) && HasMana(15));
+			Scorch.SetCondition(() => LastMoveWas(Verflare, Verholy));
+			Resolution.SetCondition(() => LastMoveWas(Scorch));
+			Scatter.SetCondition(() => HasBuff(BuffSwiftcast, BuffDualcast, BuffAcceleration, BuffChainspell));
+			Impact.SetCondition(() => CanUse(Scatter));
+
+			ForFlag(CustomComboPreset.RedMageAoECombo)
+				.ForAction(
+					() => GetBestAvailableAction(currentAction, Scatter, Impact),
+					Veraero2, Verthunder2
+				);
+
+			ForFlag(CustomComboPreset.RedMageMeleeCombo)
+				.ForAction(
+					() => GetBestAvailableAction(Riposte, ERiposte, Zwerchhau, EZwerchhau, Redoublement, ERedoublement),
+					Redoublement
+				);
+
+			ForFlag(CustomComboPreset.RedMageVerprocCombo)
+				.ForAction(
+					() => GetBestAvailableAction(Jolt, Jolt2, Verstone, Verfire, Scorch, Resolution),
+					Verstone, Verfire
+				);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using Lumina.Excel.GeneratedSheets;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/RPR.cs
+++ b/XIVComboPlugin/JobActions/RPR.cs
@@ -1,53 +1,60 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Lumina.Excel.GeneratedSheets;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class RPR
-    {
-        public const byte JobID = 39;
+	[Job("RPR")]
+	public class RPR : Job
+	{
+		private static JobAction
+			// Single Target
+			Slice               = new JobAction(24373),
+			WaxingSlice         = new JobAction(24374,	5),
+			InfernalSlice       = new JobAction(24375,	30),
+			// AoE
+			SpinningScythe      = new JobAction(24376,	25),
+			NightmareScythe     = new JobAction(24377,	45),
+			// Shroud
+			Enshroud            = new JobAction(24394,	80),
+			Communio            = new JobAction(24398,	90),
 
-        public const uint
-            // Single Target
-            Slice = 24373,
-            WaxingSlice = 24374,
-            InfernalSlice = 24375,
-            // AoE
-            SpinningScythe = 24376,
-            NightmareScythe = 24377,
-            // Shroud
-            Enshroud = 24394,
-            Communio = 24398,
+			Egress              = new JobAction(24402),
+			Ingress             = new JobAction(24401),
+			Regress             = new JobAction(24403),
 
-            Egress = 24402,
-            Ingress = 24401,
-            Regress = 24403,
+			ArcaneCircle        = new JobAction(24405),
+			PlentifulHarvest    = new JobAction(24385);
 
-            ArcaneCircle = 24405,
-            PlentifulHarvest = 24385;
+		private const ushort
+			BuffEnshrouded = 2593,
+			BuffThreshold = 2595,
+			BuffImSac1 = 2592,
+			BuffImSac2 = 3204;
+	
+		public RPR() : base()
+		{
+			WaxingSlice.SetCondition(() => LastMoveWasInCombo(Slice));
+			InfernalSlice.SetCondition(() => LastMoveWasInCombo(WaxingSlice));
+			NightmareScythe.SetCondition(() => LastMoveWasInCombo(SpinningScythe));
+			Regress.SetCondition(() => HasBuff(BuffThreshold));
+			Communio.SetCondition(() => HasBuff(BuffEnshrouded));
+			PlentifulHarvest.SetCondition(() => HasBuff(BuffImSac1, BuffImSac2));
 
-        public static class Buffs
-        {
-            public const ushort
-                Enshrouded = 2593,
-                Threshold = 2595,
-                ImSac1 = 2592,
-                ImSac2 = 3204;
-        }
+			ForFlag(CustomComboPreset.ReaperSliceCombo)
+				.ForComboActions(Slice, WaxingSlice, InfernalSlice);
 
-        public static class Debuffs
-        {
-            public const ushort
-                Placeholder = 0;
-        }
+			ForFlag(CustomComboPreset.ReaperScytheCombo)
+				.UpgradeAction(SpinningScythe, NightmareScythe);
 
-        public static class Levels
-        {
-            public const byte
-                Slice = 1,
-                WaxingSlice = 5,
-                SpinningScythe = 25,
-                InfernalSlice = 30,
-                NightmareScythe = 45,
-                Enshroud = 80,
-                Communio = 90;
-        }
-    }
+			ForFlag(CustomComboPreset.ReaperRegressFeature)
+				.UpgradeAction(Egress, Regress)
+				.UpgradeAction(Ingress, Regress);
+
+			ForFlag(CustomComboPreset.ReaperEnshroudCombo)
+				.UpgradeAction(Enshroud, Communio);
+
+			ForFlag(CustomComboPreset.ReaperArcaneFeature)
+				.UpgradeAction(ArcaneCircle, PlentifulHarvest);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/RPR.cs
+++ b/XIVComboPlugin/JobActions/RPR.cs
@@ -1,5 +1,4 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using XIVCombo.JobActions;
+﻿using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {

--- a/XIVComboPlugin/JobActions/SAM.cs
+++ b/XIVComboPlugin/JobActions/SAM.cs
@@ -1,8 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using Lumina.Excel.GeneratedSheets;
-using System;
-using System.Reflection.Emit;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/SAM.cs
+++ b/XIVComboPlugin/JobActions/SAM.cs
@@ -1,27 +1,80 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class SAM
-    {
-        public const uint
-            Yukikaze = 7480,
-            Hakaze = 7477,
-            Gekko = 7481,
-            Jinpu = 7478,
-            Kasha = 7482,
-            Shifu = 7479,
-            Mangetsu = 7484,
-            Fuga = 7483,
-            Oka = 7485,
-            ThirdEye = 7498,
-            Iaijutsu = 7867,
-            Tsubame = 16483,
-            OgiNamikiri = 25781,
-            Ikishoten = 16482,
-            KaeshiNamikiri = 25782,
-            Fuko = 25780;
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
+using Lumina.Excel.GeneratedSheets;
+using System;
+using System.Reflection.Emit;
+using XIVCombo.JobActions;
 
-        public const ushort
-            BuffOgiNamikiriReady = 2959,
-            BuffMeikyoShisui = 1233;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("SAM")]
+	public class SAM : Job
+	{
+		private static JobAction
+			Yukikaze		= new JobAction(7480,	50),
+			Hakaze			= new JobAction(7477),
+			Gekko			= new JobAction(7481,	30),
+			Jinpu			= new JobAction(7478,	4),
+			Kasha			= new JobAction(7482,	40),
+			Shifu			= new JobAction(7479,	18),
+			Mangetsu		= new JobAction(7484,	35),
+			Fuga			= new JobAction(7483),
+			Oka			    = new JobAction(7485,	45),
+			ThirdEye		= new JobAction(7498),
+			Iaijutsu		= new JobAction(7867),
+			Tsubame			= new JobAction(16483),
+			OgiNamikiri		= new JobAction(25781),
+			Ikishoten		= new JobAction(16482),
+			KaeshiNamikiri	= new JobAction(25782),
+			Fuko			= new JobAction(25780,	86);
+
+		private const ushort
+			BuffOgiNamikiriReady = 2959,
+			BuffMeikyoShisui = 1233;
+	
+		public SAM() : base()
+		{
+			SAMGauge gauge = XIVComboPlugin.JobGauges.Get<SAMGauge>();
+
+			Yukikaze.SetCondition(() => HasBuff(BuffMeikyoShisui) || LastMoveWasInCombo(Hakaze));
+			Jinpu.SetCondition(() => LastMoveWasInCombo(Hakaze));
+			Gekko.SetCondition(() => HasBuff(BuffMeikyoShisui) || LastMoveWasInCombo(Jinpu));
+			Shifu.SetCondition(() => LastMoveWasInCombo(Hakaze));
+			Kasha.SetCondition(() => HasBuff(BuffMeikyoShisui) || LastMoveWasInCombo(Shifu));
+			Mangetsu.SetCondition(() => HasBuff(BuffMeikyoShisui) || LastMoveWasInCombo(Fuga, Fuko));
+			Oka.SetCondition(() => HasBuff(BuffMeikyoShisui) || LastMoveWasInCombo(Fuga, Fuko));
+			OgiNamikiri.SetCondition(() => HasBuff(BuffOgiNamikiriReady));
+			KaeshiNamikiri.SetCondition(() => gauge.Kaeshi == Kaeshi.NAMIKIRI);
+
+			ForFlag(CustomComboPreset.SamuraiTsubameCombo)
+				.ForAction(() =>
+			{
+				JobAction resolvedTsubame = Resolve(Tsubame);
+				return resolvedTsubame != Tsubame ? resolvedTsubame : currentAction;
+			}, Iaijutsu);
+
+			// Replace Yukikaze with Yukikaze combo
+			ForFlag(CustomComboPreset.SamuraiYukikazeCombo)
+				.ForComboActions(Hakaze, Yukikaze);
+
+			// Replace Gekko with Gekko combo
+			ForFlag(CustomComboPreset.SamuraiGekkoCombo)
+				.ForComboActions(Hakaze, Jinpu, Gekko);
+
+			// Replace Kasha with Kasha combo
+			ForFlag(CustomComboPreset.SamuraiKashaCombo)
+				.ForComboActions(Hakaze, Shifu, Kasha);
+
+			// Replace Mangetsu with Mangetsu combo
+			ForFlag(CustomComboPreset.SamuraiMangetsuCombo)
+				.ForComboActions(Fuga, Fuko, Mangetsu);
+
+			// Replace Oka with Oka combo
+			ForFlag(CustomComboPreset.SamuraiOkaCombo)
+				.ForComboActions(Fuga, Fuko, Oka);
+
+			ForFlag(CustomComboPreset.SamuraiOgiCombo)
+				.ForComboActions(OgiNamikiri, KaeshiNamikiri, Ikishoten);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/SCH.cs
+++ b/XIVComboPlugin/JobActions/SCH.cs
@@ -1,11 +1,31 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using System.Diagnostics.Metrics;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class SCH
-    {
-        public const uint
-            FeyBless = 16543,
-            Consolation = 16546,
-            EnergyDrain = 167,
-            Aetherflow = 166;
-    }
+	[Job("SCH")]
+	public class SCH : Job
+	{
+		private static JobAction
+			FeyBless	= new JobAction(16543),
+			Consolation	= new JobAction(16546),
+			EnergyDrain	= new JobAction(167),
+			Aetherflow	= new JobAction(166);
+	
+		public SCH() : base()
+		{
+			SCHGauge gauge = XIVComboPlugin.JobGauges.Get<SCHGauge>();
+			Consolation.SetCondition(() => gauge.SeraphTimer > 0);
+			Aetherflow.SetCondition(() => gauge.Aetherflow == 0);
+
+			// Change Fey Blessing into Consolation when Seraph is out.
+			ForFlag(CustomComboPreset.ScholarSeraphConsolationFeature)
+				.UpgradeAction(FeyBless, Consolation);
+
+			// Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.
+			ForFlag(CustomComboPreset.ScholarEnergyDrainFeature)
+				.UpgradeAction(EnergyDrain, Aetherflow);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/SCH.cs
+++ b/XIVComboPlugin/JobActions/SCH.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
-using System.Diagnostics.Metrics;
 using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions

--- a/XIVComboPlugin/JobActions/SMN.cs
+++ b/XIVComboPlugin/JobActions/SMN.cs
@@ -1,22 +1,41 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-    public static class SMN
-    {
-        public const uint
-            Deathflare = 3582,
-            EnkindlePhoenix = 16516,
-            EnkindleBahamut = 7429,
-            DWT = 3581,
-            SummonBahamut = 7427,
-            FBTLow = 16513,
-            FBTHigh = 16549,
-            Ruin1 = 163,
-            Ruin3 = 3579,
-            BrandOfPurgatory = 16515,
-            FountainOfFire = 16514,
-            Fester = 181,
-            EnergyDrain = 16508,
-            Painflare = 3578,
-            EnergySyphon = 16510;
-    }
+	[Job("SMN")]
+	public class SMN : Job
+	{
+		private static JobAction
+			Deathflare			= new JobAction(3582),
+			EnkindlePhoenix		= new JobAction(16516),
+			EnkindleBahamut		= new JobAction(7429),
+			DWT			        = new JobAction(3581),
+			SummonBahamut		= new JobAction(7427),
+			FBTLow			    = new JobAction(16513),
+			FBTHigh			    = new JobAction(16549),
+			Ruin1			    = new JobAction(163),
+			Ruin3			    = new JobAction(3579),
+			BrandOfPurgatory	= new JobAction(16515),
+			FountainOfFire		= new JobAction(16514),
+			Fester			    = new JobAction(181),
+			EnergyDrain			= new JobAction(16508),
+			Painflare			= new JobAction(3578),
+			EnergySyphon		= new JobAction(16510,	52);
+	
+		public SMN() : base()
+		{
+			SMNGauge gauge = XIVComboPlugin.JobGauges.Get<SMNGauge>();
+			EnergyDrain.SetCondition(() => !gauge.HasAetherflowStacks);
+			EnergySyphon.SetCondition(() => CanUse(EnergyDrain));
+
+			// Change Fester into Energy Drain
+			ForFlag(CustomComboPreset.SummonerEDFesterCombo)
+				.UpgradeAction(Fester, EnergyDrain);
+
+			//Change Painflare into Energy Syphon
+			ForFlag(CustomComboPreset.SummonerESPainflareCombo)
+				.UpgradeAction(Painflare, EnergySyphon);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/SMN.cs
+++ b/XIVComboPlugin/JobActions/SMN.cs
@@ -3,7 +3,7 @@ using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("SMN")]
+	[Job("SMN", "ACN")]
 	public class SMN : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/WAR.cs
+++ b/XIVComboPlugin/JobActions/WAR.cs
@@ -2,7 +2,7 @@
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("WAR")]
+	[Job("WAR", "MRD")]
 	public class WAR : Job
 	{
 		private static JobAction

--- a/XIVComboPlugin/JobActions/WAR.cs
+++ b/XIVComboPlugin/JobActions/WAR.cs
@@ -1,19 +1,45 @@
-﻿namespace XIVComboPlugin.JobActions
-{
-    public static class WAR
-    {
-        public const uint
-            StormsPath = 42,
-            HeavySwing = 31,
-            Maim = 37,
-            StormsEye = 45,
-            MythrilTempest = 16462,
-            Overpower = 41,
-            InnerRelease = 7389,
-            PrimalRend = 25753,
-            Berserk = 38;
+﻿using XIVCombo.JobActions;
 
-        public const ushort
-            BuffPrimalRendReady = 2624;
-    }
+namespace XIVComboPlugin.JobActions
+{
+	[Job("WAR")]
+	public class WAR : Job
+	{
+		private static JobAction
+			HeavySwing		= new JobAction(31		),
+			Maim			= new JobAction(37,		4),
+			StormsPath		= new JobAction(42,		26),
+			StormsEye		= new JobAction(45,		50),
+			Overpower		= new JobAction(41		),
+			MythrilTempest	= new JobAction(16462,	40),
+			InnerRelease	= new JobAction(7389	),
+			PrimalRend		= new JobAction(25753	),
+			Berserk			= new JobAction(38		);
+
+		private const ushort
+			BuffPrimalRendReady = 2624;
+
+		public WAR() : base()
+		{
+			Maim.SetCondition(() => LastMoveWasInCombo(HeavySwing));
+			StormsPath.SetCondition(() => LastMoveWasInCombo(Maim));
+			StormsEye.SetCondition(() => LastMoveWasInCombo(Maim));
+			MythrilTempest.SetCondition(() => LastMoveWasInCombo(Overpower));
+
+			// Replace Storm's Path with Storm's Path combo
+			ForFlag(CustomComboPreset.WarriorStormsPathCombo)
+				.ForComboActions(HeavySwing, Maim, StormsPath);
+			// Replace Storm's Eye with Storm's Eye combo
+			ForFlag(CustomComboPreset.WarriorStormsEyeCombo)
+				.ForComboActions(HeavySwing, Maim, StormsEye);
+			// Replace Mythril Tempest with Mythril Tempest combo
+			ForFlag(CustomComboPreset.WarriorMythrilTempestCombo)
+				.ForComboActions(Overpower, MythrilTempest);
+			ForFlag(CustomComboPreset.WarriorIRCombo)
+				.ForAction(
+					() => HasBuff(BuffPrimalRendReady) ? PrimalRend : currentAction,
+					InnerRelease, Berserk
+				);
+		}
+	}
 }

--- a/XIVComboPlugin/JobActions/WHM.cs
+++ b/XIVComboPlugin/JobActions/WHM.cs
@@ -3,19 +3,18 @@ using XIVCombo.JobActions;
 
 namespace XIVComboPlugin.JobActions
 {
-	[Job("WHM")]
+	[Job("WHM", "CNJ")]
 	public class WHM : Job
 	{
 		private static JobAction
 			Solace	= new JobAction(16531),
 			Rapture	= new JobAction(16534),
 			Misery	= new JobAction(16535);
-	
+
 		public WHM() : base()
 		{
 			WHMGauge gauge = XIVComboPlugin.JobGauges.Get<WHMGauge>();
 			Misery.SetCondition(() => gauge.BloodLily >= 3);
-
 			// Replace Solace with Misery when full blood lily
 			ForFlag(CustomComboPreset.WhiteMageSolaceMiseryFeature)
 				.UpgradeAction(Solace, Misery);

--- a/XIVComboPlugin/JobActions/WHM.cs
+++ b/XIVComboPlugin/JobActions/WHM.cs
@@ -1,10 +1,28 @@
-﻿namespace XIVComboPlugin.JobActions
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using XIVCombo.JobActions;
+
+namespace XIVComboPlugin.JobActions
 {
-	public static class WHM
+	[Job("WHM")]
+	public class WHM : Job
 	{
-		public const uint
-			Solace = 16531,
-			Rapture = 16534,
-			Misery = 16535;
+		private static JobAction
+			Solace	= new JobAction(16531),
+			Rapture	= new JobAction(16534),
+			Misery	= new JobAction(16535);
+	
+		public WHM() : base()
+		{
+			WHMGauge gauge = XIVComboPlugin.JobGauges.Get<WHMGauge>();
+			Misery.SetCondition(() => gauge.BloodLily >= 3);
+
+			// Replace Solace with Misery when full blood lily
+			ForFlag(CustomComboPreset.WhiteMageSolaceMiseryFeature)
+				.UpgradeAction(Solace, Misery);
+
+			// Replace Rapture with Misery when full blood lily
+			ForFlag(CustomComboPreset.WhiteMageRaptureMiseryFeature)
+				.UpgradeAction(Rapture, Misery);
+		}
 	}
 }


### PR DESCRIPTION
# Summary
## What this is
I was messing around with different changes/additions to the existing job action replacement logic and felt like there was probably a better way to organize it all. Then I saw the changes you made in the RPR class and it seemed to me like you were starting to experiment with organizing the data better, so I thought I'd submit what I came up with. It's a **very** heavy rewrite and I wouldn't blame you for pushing back heavily or refusing to implement it, but I had fun working on it either way.
## Goals of this refactor
### Make it easier to find and tweak both values (skill/buff IDs) and logic.
You already had the skill & buff IDs separated into data container classes, so all I had to do was then also move the skill logic per job into its associated job class.

### Encapsulate the ubiquitous patterns in the code/structure to allow better abstraction and optimization (DRY.)
I identified and attempted to encapsulate & abstract the following patterns:
* All action replacements were conditional to flags being turned on
* Most action replacement code blocks only affected a single skill at a time
* All actions have a level requirement (at least 1, technically)
* Most of the action replacements were for combos which followed the same set of logic
  * The next most common action replacements were for skill "upgrades"
* Most actions we care about in replacement logic are conditional to
  * Having a buff
  * Job gauge status
  * Being part of a combo

### You should be able to tell easily at a glance what a given custom combo preset flag does without comments/a description.
I created some sub-classes whose sole purpose is to organize the replacement logic by custom combo preset flags. This makes writing the logic much more abstracted and also much more readable (in my opinion.) I created convenience functions to make writing the most common types of replacement logic (as identified in the previous point) easier.

### The `GetIconDetour` function sometimes has to go through all of the top level conditionals if it doesn't short-circuit early when realistically the plugin _should_ follow a tree structure and always short circuit regardless of if a replacement occurs.
Since all replacement logic is now encapsulated within the pre-existing job classes and both the job classes and job action instances are mapped to their own dictionaries, no massive amount of conditional checking is necessary; a tree gets constructed on load, linking all jobs, flags, and actions together.

# What this does specifically
## Additions
Two new classes were added:
1. Job (with JobConfig & JobConfigData subclasses)
2. JobAction

Job is the new base class for all pre-existing data container classes for the jobs. It contains helper functions and logic to facilitate writing action replacement more easily.

JobAction is a data container class which mostly just encapsulates the action ID and level requirement. You can, however, also tack on a "condition" which is what allows you to simply list actions together in a combo without an explicit conditional in code there.
## Things that changed
### Action replacement logic
All action replacement logic moved from within the `GetIconDetour` to its respective job class. All logic is now contained within one of three functions:
1. ForAction
2. ForComboActions
3. UpgradeAction
### How the new action ID gets passed around
1. The current class is gotten
2. The map to that class' flags is retrieved
3. Each flag that is enabled is sequentially checked if it maps to the current action
4. Once the action is found, the logic is ran and the tree traversal ends with the current action either being replaced or not.
5. If the action is not mapped, or the flag that maps it is disabled, then only part of the tree is traversed, no logic is ran, and it shortcuts early into the same `iconHook.Original` that it used to.
### Many things got rescoped
* The action IDs & metadata are now scoped to their respective classes as opposed to being public static.
* This means subclassing the level and buff data is no longer necessary because it isn't accessed outside of its respective class.
* Because everything is now class-scoped, you can create helper functions to further simplify coding action replacement logic. _E.g. Red Mage has a `HasMana` function since checking for a minimum amount of black & white mana is used a few times._
### Action usability is split from how actions are grouped
* Combos are defined by grouping actions together, but the conditions for when certain skills in a combo are usable are separately defined. This both makes things more concise and readable, and has the added benefit of being able to handle job action upgrades more easily because you can simply set the upgraded action's condition to be whether its predecessor is usable, and then just chain them together in their respective combos.
* This also makes it so that if a given action is used in multiple combos, you only have to define its conditions once, both saving on code and also creating a single source of truth which makes updating/tweaking things much easier in the future.
* The minimum level requirement for actions are defined during JobAction construction and is always respected regardless of any other defined conditions, further simplifying coding and tweaking.
# A brief rundown of how the program flows with this refactor
## Initialization
1. The `IconReplacer` constructor is called and initializes everything as before.
2. The static `Job.Initialize()` function is called, passing in the `clientState`, `Configuration`, and `iconHook` variables.
3. Reflection is used to get all `Job` children with the `JobAttribute` as well as the passed in job abbreviations.
4. Each `Job` child is instantiated and mapped in a dictionary to its abbreviation, which is then returned back to `IconReplacer` and stored for later use.
## Main logic
1. `GetIconDetour` is called and `lastMove`, `comboTime`, and `level` are derived as before with the addition of `classAbbreviation`.
2. The `jobsMap` dictionary returned by `Job.Initialize()` is checked against the current class' abbreviation and the corresponding class' `ReplaceIcon` function is called which will return true if the current action is mapped (and its flag is enabled.)
3. The icon is either replaced or not, and the program falls through to passing the current action back as before.
## `JobConfig`
1. When a `Job` is instantiated, its constructor will contain calls to `ForFlag` which maps an internal dictionary entry for that custom combo preset flag with a `JobConfigData` instance.
2. The returned `JobConfigData` instance can then have a few functions called on it to set up action replacement logic. These functions are: `ForAction`, `ForComboActions`, and `UpgradeAction`
3. Each of these functions vary slightly in how, but they all then map one or more actions to a function which returns the new action ID, finishing up the tree data.
## `Job`
1. Once the instance is constructed, each action that needs it has its usability condition set.
   * Additional variables like a class gauge can also be set up.
2. `ForFlag`, `ForAction`, `ForComboActions`, and `UpgradeAction` are then called to map Flags => Actions => Logic.
3. `ForAction` usually utilizes `GetBestAvailableAction` which simply returns the right-most action which is usable based on the action conditions set.
4. `ForComboActions` and `UpgradeAction` are just convenience wrappers of `ForAction` and `GetBestAvailableAction`.
   * `ForComboActions` automatically maps the logic to the last action listed (because the precedent for combo actions is the last action in the combo gets replaced.)
   * `UpgradeAction` automatically maps the logic to the first action listed (so that it reads like the first action will be "upgraded" with any of the actions that follow.)

### Example
**Given:** A Job has a combo using actions A, B, and C and the level requirement for B is 10 and C is 20.
* You would define all three actions at the top of the Job class and set the level requirements for B and C.
* In the constructor, you would set the condition of B to `LastMoveWasInCombo(A)` and the condition of C to `LastMoveWasInCombo(B)`. This translates as you would expect to the original `comboTime > 0 && lastMove == B/C`.
* After the relevant `ForFlag` call, you would then call `ForComboActions(A, B, C)`.
  * `ForAction` is then called internally and returns `GetBestAvailableAction([A, B, C])` while mapping to all three abilities separately in the internal `JobConfigData.actionLogicMap` dictionary.
  * `GetBestAvailableAction` then calls `CanUse` on its passed array of [A, B, C] to filter it down to only the currently-useable actions. This means if you are only level 1, B and C will be filtered out due to not meeting level requirements. Similarly, if the last move you used was A, then C will be filtered out. 
  * Finally it returns the last (right-most) action remaining after the filter. This is why you should always pass actions in the order of most to least accessible to `GetBestAvailableAction`. This has the additional benefit of easily being able to pass in upgraded action variants right after the normal variant and they'll automatically be used instead as long as you set up their condition logic correctly (see Red Mage's melee combo.)
### Notes
* If you have standard combo logic, but you want to map it to a different action than the last/first one (or want to map it to all/multiple actions), then you have to call `ForAction` yourself and cannot rely on the convenience functions. E.g. both of Bard's combos map to two abilities in the combo instead of just one like a standard tank 1,2,3 combo.
* You can chain the three action functions together on each flag to handle multiple actions' replacement logic.
* You cannot (should not) use the same action in multiple `ForAction` calls. Because this all works on tree (dictionary) traversal and not iteration, you can only map an action once.
   * Technically speaking, you could map the same action once to multiple flags and as long as only one of those flags is enabled at a time, it will work as expected, but since the config currently does not support mutually-exclusive flags, this is a bad idea. I'm not sure if providing variant action replacement logic meshes well with the ethos of this plugin. Could be a future feature potentially.

# Possible improvements
1. Since everything is mapped to a tree, a further optimization could be made where when the plugin is loaded or the user changes the config settings, you selectively map classes and flags in the internal dictionaries only when they are enabled (in the case of classes when they have at least one flag enabled.) I don't know how much of a performance improvement this would yield since there isn't any high level iteration happening regardless, but it should _theoretically_ improve it.
2. I'm not sure how/if this would improve anything, but now that all job actions are internally mapped, the accursed `CheckIsIconReplaceableDetour` could actually check to see if the actionID it's passed is mapped (and its flag is enabled.) I'm assuming this would affect how many skills are passed to `GetIconDetour`, so combining this with the first improvement might make a measurable difference on lower-end machines with certain setups.
3. Defining standard combos could potentially be further simplified where the only condition of actions is `LastMoveWasInCombo`. I didn't because I had to draw the line somewhere on how "convenient" to make everything before it just got ridiculous.