### PR TITLE
Feature: partial samurai combos

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -67,12 +67,17 @@ namespace XIVComboPlugin
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain", 34)]
         SamuraiOkaCombo = 1L << 15,
 
+        [CustomComboInfo("Partial Gekko Combo", "Replace Gekko with a partial Gekko combo chain (Jinpu -> Gekko)", 34)]
+        SamuraiPartialGekkoCombo = 1L << 50,
+
+        [CustomComboInfo("Partial Kasha Combo", "Replace Kasha with a partial Kasha combo chain (Shifu -> Kasha)", 34)]
+        SamuraiPartialKashaCombo = 1L << 51,
+
         [CustomComboInfo("Iaijutsu into Tsubame", "Replace Iaijutsu with Tsubame after using an Iaijutsu", 34)]
         SamuraiTsubameCombo = 1L << 56,
 
         [CustomComboInfo("Ogi Namikiri Combo", "Replace Ikishoten with Ogi Namiki and Kaeshi Namikiri when appropriate", 34)]
         SamuraiOgiCombo = 1L << 62,
-
 
         // NINJA
         [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain", 30)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -403,6 +403,36 @@ namespace XIVComboPlugin
                     return SAM.Ikishoten;
                 }
 
+            // Replace Gekko with a partial Gekko combo chain (Jinpu -> Gekko)
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiPartialGekkoCombo))
+                if (actionID == SAM.Gekko)
+                {
+                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
+                        return SAM.Gekko;
+                    if (comboTime > 0)
+                    {
+                        if (lastMove == SAM.Jinpu && level >= 30)
+                            return SAM.Gekko;
+                    }
+
+                    return SAM.Jinpu;
+                }
+
+            // Replace Kasha with a partial Kasha combo chain (Shifu -> Kasha)
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiPartialKashaCombo))
+                if (actionID == SAM.Kasha)
+                {
+                    if (SearchBuffArray(SAM.BuffMeikyoShisui))
+                        return SAM.Kasha;
+                    if (comboTime > 0)
+                    {
+                        if (lastMove == SAM.Shifu && level >= 40)
+                            return SAM.Kasha;
+                    }
+
+                    return SAM.Shifu;
+                }
+
             // NINJA
 
             // Replace Armor Crush with Armor Crush combo

--- a/XIVComboPlugin/XIVCombo.csproj
+++ b/XIVComboPlugin/XIVCombo.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Feature">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>1.7.23</Version>
+    <Version>1.7.24</Version>
   </PropertyGroup>
   <PropertyGroup>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
### What it does
This PR adds two new combos to XIV Combo. These are:
- Partial Gekko Combo (Jinpu -> Gekko)
- Partial Kasha Combo (Shifu -> Kasha)

### Reasoning
I use XIV Combo primarily to collapse combos without any branching paths or decision points into a single button. 

For example, on GNB I use the Solid Barrel combo and the Demon Slaughter combo, as there are no branching paths. But on the Ninja, I only use the Aeolian Edge and Hakke Mujinsatsu combos, and leave Armor Crush as is. This is because it is a branching path for ending the Aeolian Edge combo.

On Samurai, I wanted to have Jinpu -> Gekko and Shifu -> Kasha collapsed into one button because I have already made the choice between which of the three Hakaze follow up combos I want to use. This saves on some button space but keeps the feeling and rhythm of Samurai's combo flow intact.

A huge bonus is not having duplicate icons on my hotbar anymore! I still save a few buttons but don't have to look at 4 Hakazes on my bar at once and not remember which button starts each combo, as each action only exists in one combo chain.

### Conclusion
I have been using this modification on my own computer for months now but just now decided to create an actual git commit and PR as I would love if this feature could be in the main project. 

Sorry for the really long explanation! I hope you'll consider my addition.