### PR TITLE
SMN energy siphon only available when high enough level for it.

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -632,8 +632,14 @@ namespace XIVComboPlugin
                 if (actionID == SMN.Painflare)
                 {
                     if (!JobGauges.Get<SMNGauge>().HasAetherflowStacks)
-                        return SMN.EnergySyphon;
-                    return SMN.Painflare;
+                        if (level >= 52)
+                            return SMN.EnergySyphon;
+                        else
+                            return SMN.EnergyDrain;
+                    if (level >= 40)
+                        return SMN.Painflare;
+                    else
+                        return SMN.Fester;
                 }
 
             // SCHOLAR
@@ -907,9 +913,10 @@ namespace XIVComboPlugin
         {
             if (needle == 0) return false;
             var buffs = clientState.LocalPlayer.StatusList;
-            for (var i = 0; i < buffs.Length; i++)
+            for (var i = 0; i < buffs.Length; i++) {
                 if (buffs[i].StatusId == needle)
                     return true;
+            }
             return false;
         }        
     }


### PR DESCRIPTION
Otherwise use energy drain. Between levels 40 and 51, summoner has energy drain but not siphon, but does have painflare. So siphon -> painflare does not make sense. It should instead be energy drain -> painflare

Also converts painflare to fester when painflare unavailable. Saves 2 buttons that are otherwise only needed in low level content. As this only affects hotbar configurations in low level level synced content it purely is a convenience and does not remove any skill from the game.

However this QOL feature is still useful to me. For example I like having an AOE and a single target hotbar, I switch between these with a controller button. being able to use energy siphon without having to rebind it every single time is helpful.

Closes #286 