### PR TITLE
Updated PLD and Sam to 7.0

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -258,6 +258,13 @@ namespace XIVComboPlugin
                 {
                     if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
                         return iconHook.Original(self, PLD.Confiteor);
+
+                    if (SearchBuffArray(PLD.BuffBladeOfHonor)) 
+                        return PLD.BladeOfHonor;
+
+                    if (level >= 96)
+                        return PLD.Imperator;
+
                     return PLD.Requiescat;
                 }
 
@@ -330,6 +337,9 @@ namespace XIVComboPlugin
                     if (comboTime > 0)
                         if (lastMove == SAM.Hakaze && level >= 50)
                             return SAM.Yukikaze;
+
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -347,6 +357,8 @@ namespace XIVComboPlugin
                             return SAM.Gekko;
                     }
 
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -364,6 +376,8 @@ namespace XIVComboPlugin
                             return SAM.Kasha;
                     }
 
+                    if (level >= 92) 
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -402,7 +416,9 @@ namespace XIVComboPlugin
                         return SAM.OgiNamikiri;
                     if (JobGauges.Get<SAMGauge>().Kaeshi == Kaeshi.NAMIKIRI)
                         return SAM.KaeshiNamikiri;
-                        
+
+                    if (SearchBuffArray(SAM.BuffZanshinReady)) return SAM.Zanshin;
+
                     return SAM.Ikishoten;
                 }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -335,8 +335,11 @@ namespace XIVComboPlugin
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
                         return SAM.Yukikaze;
                     if (comboTime > 0)
-                        if (lastMove == SAM.Hakaze && level >= 50)
+                    {
+                        if ((lastMove == SAM.Hakaze && level >= 50) || lastMove ==SAM.Gyuofu)
                             return SAM.Yukikaze;
+                    }
+
 
                     if (level >= 92)
                         return SAM.Gyuofu;
@@ -351,7 +354,7 @@ namespace XIVComboPlugin
                         return SAM.Gekko;
                     if (comboTime > 0)
                     {
-                        if (lastMove == SAM.Hakaze && level >= 4)
+                        if ((lastMove == SAM.Hakaze && level >= 4) || lastMove == SAM.Gyuofu)
                             return SAM.Jinpu;
                         if (lastMove == SAM.Jinpu && level >= 30)
                             return SAM.Gekko;
@@ -370,7 +373,7 @@ namespace XIVComboPlugin
                         return SAM.Kasha;
                     if (comboTime > 0)
                     {
-                        if (lastMove == SAM.Hakaze && level >= 18)
+                        if ((lastMove == SAM.Hakaze && level >= 18) || lastMove == SAM.Gyuofu)
                             return SAM.Shifu;
                         if (lastMove == SAM.Shifu && level >= 40)
                             return SAM.Kasha;
@@ -613,7 +616,7 @@ namespace XIVComboPlugin
                 if (actionID == AST.Play)
                 {
                     var gauge = JobGauges.Get<ASTGauge>();
-                    switch (gauge.DrawnCard)
+                    switch (gauge.DrawnCards[0])
                     {
                         case CardType.BALANCE:
                             return AST.Balance;

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -420,8 +420,6 @@ namespace XIVComboPlugin
                     if (JobGauges.Get<SAMGauge>().Kaeshi == Kaeshi.NAMIKIRI)
                         return SAM.KaeshiNamikiri;
 
-                    if (SearchBuffArray(SAM.BuffZanshinReady)) return SAM.Zanshin;
-
                     return SAM.Ikishoten;
                 }
 
@@ -616,7 +614,7 @@ namespace XIVComboPlugin
                 if (actionID == AST.Play)
                 {
                     var gauge = JobGauges.Get<ASTGauge>();
-                    switch (gauge.DrawnCards[0])
+                    switch (gauge.DrawnCard)
                     {
                         case CardType.BALANCE:
                             return AST.Balance;

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -14,10 +14,13 @@
             Confiteor = 16459,
             BladeOfFaith = 25748,
             BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+            BladeOfValor = 25750,
+            Imperator = 36921,
+            BladeOfHonor = 36922;
 
         public const ushort
             BuffRequiescat = 1368,
-            BuffBladeOfFaithReady = 3019;
+            BuffBladeOfFaithReady = 3019,
+            BuffBladeOfHonor = 3831;
     }
 }

--- a/XIVComboPlugin/JobActions/SAM.cs
+++ b/XIVComboPlugin/JobActions/SAM.cs
@@ -18,10 +18,13 @@
             OgiNamikiri = 25781,
             Ikishoten = 16482,
             KaeshiNamikiri = 25782,
-            Fuko = 25780;
+            Fuko = 25780,
+            Gyuofu = 36963,
+            Zanshin = 36964;
 
         public const ushort
             BuffOgiNamikiriReady = 2959,
-            BuffMeikyoShisui = 1233;
+            BuffMeikyoShisui = 1233,
+            BuffZanshinReady = 3855;
     }
 }


### PR DESCRIPTION
Those are the only ones I go to 100 that I can confirm, not sure if you want to do piecemeal PRs so other people can push the class they know. I'll try to do more a few more tomorrow based on patch notes.

SAM changes:

- Hakaze becomes Gyufo at level >=92 for the 1-2-3 combos.
- Added Zenshin to the Ikishoten combo, after Onigiri, based on the Zenshin Ready buff.

PLD changes:

-Requiescath becomes Imperator at level >= 96
-Imperator becomes Blade of Honour if the buff Blade of Honour Ready is up.