### PR TITLE
Update DRG, SCH and BLM and added PCT to 7.0

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -9,8 +9,8 @@ namespace XIVComboPlugin
         None = 0,
 
         // DRAGOON
-        [CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
-        DragoonJumpFeature = 1L << 44,
+        //[CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
+        //DragoonJumpFeature = 1L << 44,
 
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
         DragoonCoerthanTormentCombo = 1L << 0,
@@ -111,8 +111,8 @@ namespace XIVComboPlugin
         [CustomComboInfo("Enochian Stance Switcher", "Change Fire 4 and Blizzard 4 to the appropriate element depending on stance, as well as Flare and Freeze", 25)]
         BlackEnochianFeature = 1L << 25,
 
-        [CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
-        BlackLeyLines = 1L << 28,
+        //[CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
+        //BlackLeyLines = 1L << 28,
 
         // ASTROLOGIAN
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior", 33)]
@@ -127,8 +127,8 @@ namespace XIVComboPlugin
         SummonerESPainflareCombo = 1L << 40,
         
         // SCHOLAR
-        [CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
-        ScholarSeraphConsolationFeature = 1L << 29,
+        //[CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
+        //ScholarSeraphConsolationFeature = 1L << 29,
 
         [CustomComboInfo("ED Aetherflow", "Change Energy Drain into Aetherflow when you have no more Aetherflow stacks", 28)]
         ScholarEnergyDrainFeature = 1L << 37,

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -188,6 +188,19 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Arcane Circle Combo", "Replace Arcane Circle with Plentiful Harvest while you have Immortal Sacrifice.", 39)]
         ReaperArcaneFeature = 1L << 30,
+
+        //PICTOMANCER
+        [CustomComboInfo("Red to Blue combo","Replace Fire combo with Blizzard combo when Subtractive Pallet is active.",42)]
+        PictoSubtractivePallet = 1L << 31,
+
+        [CustomComboInfo("Motifs and Muses", "Replace Motifs with their relevant Muses.", 42)]
+        PictoMotifMuseFeature = 1L << 34,
+
+        [CustomComboInfo("Starry Sky to Star Prism", "Replace Starry Sky with Star Prism.", 42)]
+        PictoStarrySkyCombo = 1L << 38,
+
+        [CustomComboInfo("Holy white to Comet Black", "Replace Holy in White with Comet in black when Monochrome Tones is active.", 42)]
+        PictoHolyWhiteCombo = 1L << 43,
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -162,9 +162,8 @@ namespace XIVComboPlugin
                         }
                         if ((lastMove == DRG.ChaosThrust || lastMove == DRG.ChaoticSpring) && level >= 58)
                             return DRG.WheelingThrust;
-                        if ((lastMove == DRG.WheelingThrust) && level >= 64) //Drakesbane action
-                            return DRG.FangAndClaw;
-                        
+                        if ((lastMove == DRG.WheelingThrust) && level >= 64)
+                            return DRG.Drakesbane;
                     }
                     //These buffs no longer exist and are now incorporated into the overall combo
                     /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
@@ -172,6 +171,7 @@ namespace XIVComboPlugin
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
                     */
+                    
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
                     
@@ -200,8 +200,8 @@ namespace XIVComboPlugin
                         }
                         if ((lastMove == DRG.FullThrust || lastMove == DRG.HeavensThrust) && level >= 56)
                             return DRG.FangAndClaw;
-                        if ((lastMove == DRG.FangAndClaw) && level >= 64) //Drakesbane action
-                            return DRG.WheelingThrust;
+                        if ((lastMove == DRG.FangAndClaw) && level >= 64)
+                            return DRG.Drakesbane;
                     }
                     //These buffs no longer exist and are now incorporated into the overall combo
                     /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
@@ -209,6 +209,7 @@ namespace XIVComboPlugin
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
                     */
+                    
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -115,15 +115,16 @@ namespace XIVComboPlugin
 
             // DRAGOON
 
+            //SE built this in, so obsolete now
             // Change Jump/High Jump into Mirage Dive when Dive Ready
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
                 if (actionID == DRG.Jump || actionID == DRG.HighJump)
                 {
                     if (SearchBuffArray(1243))
                         return DRG.MirageDive;
                     return iconHook.Original(self, DRG.Jump);
                 }
-
+            */
             // Replace Coerthan Torment with Coerthan Torment combo chain
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonCoerthanTormentCombo))
                 if (actionID == DRG.CTorment)
@@ -146,22 +147,34 @@ namespace XIVComboPlugin
                     if (comboTime > 0)
                     {
                         if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 18)
-                            return DRG.Disembowel;
-                        if (lastMove == DRG.Disembowel)
+                        {
+                            if (level >= 96)
+                                return DRG.SpiralBlow;
+                            if (level >= 18)
+                                return DRG.Disembowel;
+                        }
+                        if (lastMove == DRG.Disembowel || lastMove == DRG.SpiralBlow)
                         {
                             if (level >= 86)
                                 return DRG.ChaoticSpring;
                             if (level >= 50)
                                 return DRG.ChaosThrust;
                         }
+                        if ((lastMove == DRG.ChaosThrust || DRG.ChaoticSpring) && level >= 58)
+                            return DRG.WheelingThrust;
+                        if ((lastMove == DRG.WheelingThrust) && level >= 64) //Drakesbane action
+                            return DRG.FangAndClaw;
+                        
                     }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
+                    //These buffs no longer exist and are now incorporated into the overall combo
+                    /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
                         return DRG.FangAndClaw;
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
+                    */
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
-
+                    
                     return DRG.TrueThrust;
                 }
 
@@ -171,20 +184,31 @@ namespace XIVComboPlugin
                 {
                     if (comboTime > 0)
                     {
-                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 4)
-                            return DRG.VorpalThrust;
-                        if (lastMove == DRG.VorpalThrust)
+                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 4) 
+                        {
+                            if (level >= 96)
+                                return DRG.LanceBarrage;
+                            if (level >= 4)
+                                return DRG.VorpalThrust;
+                        }
+                        if (lastMove == DRG.VorpalThrust || DRG.LanceBarrage)
                         {
                             if (level >= 86)
                                 return DRG.HeavensThrust;
                             if (level >= 26)
                                 return DRG.FullThrust;
                         }
+                        if ((lastMove == DRG.FullThrust || DRG.HeavensThrust) && level >= 56)
+                            return DRG.FangAndClaw;
+                        if ((lastMove == DRG.FangAndClaw) && level >= 64) //Drakesbane action
+                            return DRG.WheelingThrust;
                     }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
+                    //These buffs no longer exist and are now incorporated into the overall combo
+                    /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
                         return DRG.FangAndClaw;
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
+                    */
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
 
@@ -582,14 +606,14 @@ namespace XIVComboPlugin
             }
 
             // Ley Lines and BTL
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
                 if (actionID == BLM.LeyLines)
                 {
                     if (SearchBuffArray(BLM.BuffLeyLines) && level >= 62)
                         return BLM.BTL;
                     return BLM.LeyLines;
                 }
-
+            */
             // ASTROLOGIAN
 
             // Make cards on the same button as play
@@ -638,13 +662,13 @@ namespace XIVComboPlugin
             // SCHOLAR
 
             // Change Fey Blessing into Consolation when Seraph is out.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
                 if (actionID == SCH.FeyBless)
                 {
                     if (JobGauges.Get<SCHGauge>().SeraphTimer > 0) return SCH.Consolation;
                     return SCH.FeyBless;
                 }
-
+            */
             // Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarEnergyDrainFeature))
                 if (actionID == SCH.EnergyDrain)

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -924,6 +924,93 @@ namespace XIVComboPlugin
                 }
             }
 
+            //Pictomancer
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoSubtractivePallet))
+            {
+                if (actionID == PCT.Fire1)
+                {
+                    bool isSubPallet = SearchBuffArray(PCT.SubPallet);
+
+                    if (SearchBuffArray(PCT.Aether1))
+                        return isSubPallet ? PCT.Stone1 : PCT.Aero1;
+
+                    if (SearchBuffArray(PCT.Aether2))
+                        return isSubPallet ? PCT.Thunder1 : PCT.Water1;
+
+                    return isSubPallet ? PCT.Bliz1 : PCT.Fire1;
+                }
+
+                if (actionID == PCT.Fire2)
+                {
+                    bool isSubPallet = SearchBuffArray(PCT.SubPallet);
+
+                    if (SearchBuffArray(PCT.Aether1))
+                        return isSubPallet ? PCT.Stone2 : PCT.Aero2;
+
+                    if (SearchBuffArray(PCT.Aether2))
+                        return isSubPallet ? PCT.Thunder2 : PCT.Water2;
+
+                    return isSubPallet ? PCT.Bliz2 : PCT.Fire2;
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoHolyWhiteCombo))
+            {
+                if (actionID == PCT.HolyWhite)
+                {
+                    if (SearchBuffArray(PCT.Monochrome))
+                        return PCT.CometBlack;
+                    return PCT.HolyWhite;
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMotifMuseFeature))
+            {
+                var PCTGauge = JobGauges.Get<PCTGauge>();
+                if (actionID == PCT.CreatureMotif)
+                {
+                    if ((PCTGauge.CanvasFlags & CanvasFlags.Pom) != 0)
+                        return PCT.PomMuse;
+
+                    if ((PCTGauge.CanvasFlags & CanvasFlags.Wing) != 0)
+                        return PCT.WingMuse;
+
+                    if ((PCTGauge.CanvasFlags & CanvasFlags.Claw) != 0)
+                        return PCT.ClawMuse;
+
+                    if ((PCTGauge.CanvasFlags & CanvasFlags.Maw) != 0)
+                        return PCT.FangMuse;
+                }
+
+                if (actionID == PCT.WeaponMotif)
+                {
+                    if (PCTGauge.WeaponMotifDrawn)
+                        return PCT.StrikingMuse;
+
+                    if (lastMove == PCT.HammerStamp)
+                        return PCT.HammerBrush;
+
+                    if (lastMove == PCT.HammerBrush)
+                        return PCT.HammerPolish;
+
+                    if (SearchBuffArray(PCT.HammerReady))
+                        return PCT.HammerStamp;
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoStarrySkyCombo))
+            {
+                var PCTGauge = JobGauges.Get<PCTGauge>();
+                if (actionID == PCT.LandscapeMotif)
+                {
+                    if (PCTGauge.LandscapeMotifDrawn)
+                        return PCT.StarryMuse;
+                    if (SearchBuffArray(PCT.StarStruck))
+                        return PCT.StarPrism;
+                    return PCT.StarryMotif;
+                }
+            }
+
             return iconHook.Original(self, actionID);
         }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -160,7 +160,7 @@ namespace XIVComboPlugin
                             if (level >= 50)
                                 return DRG.ChaosThrust;
                         }
-                        if ((lastMove == DRG.ChaosThrust || DRG.ChaoticSpring) && level >= 58)
+                        if ((lastMove == DRG.ChaosThrust || lastMove == DRG.ChaoticSpring) && level >= 58)
                             return DRG.WheelingThrust;
                         if ((lastMove == DRG.WheelingThrust) && level >= 64) //Drakesbane action
                             return DRG.FangAndClaw;
@@ -191,14 +191,14 @@ namespace XIVComboPlugin
                             if (level >= 4)
                                 return DRG.VorpalThrust;
                         }
-                        if (lastMove == DRG.VorpalThrust || DRG.LanceBarrage)
+                        if (lastMove == DRG.VorpalThrust || lastMove == DRG.LanceBarrage)
                         {
                             if (level >= 86)
                                 return DRG.HeavensThrust;
                             if (level >= 26)
                                 return DRG.FullThrust;
                         }
-                        if ((lastMove == DRG.FullThrust || DRG.HeavensThrust) && level >= 56)
+                        if ((lastMove == DRG.FullThrust || lastMove == DRG.HeavensThrust) && level >= 56)
                             return DRG.FangAndClaw;
                         if ((lastMove == DRG.FangAndClaw) && level >= 64) //Drakesbane action
                             return DRG.WheelingThrust;

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -22,8 +22,8 @@
             WheelingThrust = 3556,
             FullThrust = 84,
             VorpalThrust = 78,
-            LanceBarrage = 36901,
-            SpiralBlow = 36903,
+            LanceBarrage = 36954,
+            SpiralBlow = 36955,
             Drakesbane = 36952;
 
 

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -21,7 +21,10 @@
             FangAndClaw = 3554,
             WheelingThrust = 3556,
             FullThrust = 84,
-            VorpalThrust = 78;
+            VorpalThrust = 78,
+            LanceBarrage = 36901,
+            SpiralBlow = 36903;
+
 
         public const ushort
             BuffFangAndClawReady = 802,

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -23,7 +23,8 @@
             FullThrust = 84,
             VorpalThrust = 78,
             LanceBarrage = 36901,
-            SpiralBlow = 36903;
+            SpiralBlow = 36903,
+            Drakesbane = 36952;
 
 
         public const ushort

--- a/XIVComboPlugin/JobActions/PCT.cs
+++ b/XIVComboPlugin/JobActions/PCT.cs
@@ -1,0 +1,54 @@
+﻿namespace XIVComboPlugin.JobActions
+{
+    public static class PCT
+    {
+        public const uint
+
+            Fire1 = 34650,
+            Aero1 = 34651,
+            Water1 = 34652,
+            Fire2 = 34656,
+            Aero2 = 34657,
+            Water2 = 34658,
+
+            Bliz1 = 34653,
+            Stone1 = 34654,
+            Thunder1 = 34655,
+            Bliz2 = 34659,
+            Stone2 = 34660,
+            Thunder2 = 34661,
+
+            CreatureMotif = 34689,
+            PomMotif = 34664,
+            WingMotif = 34665,
+            ClawMotif = 34666,
+            MawMotif = 34667,
+            PomMuse = 34670,
+            WingMuse = 34671,
+            ClawMuse = 34672,
+            FangMuse = 34673,
+
+            WeaponMotif = 34690,
+            StrikingMuse = 34674,
+            HammerStamp = 34678,
+            HammerBrush = 34679,
+            HammerPolish = 34680,
+
+            LandscapeMotif = 34691,
+            StarryMuse = 34675,
+            StarryMotif = 34669,
+
+            StarPrism = 34681,
+
+            HolyWhite = 34662,
+            CometBlack = 34663;
+
+        public const ushort
+            SubPallet = 3674,
+            HammerReady = 3680,
+            StarStruck = 3681,
+            Aether1 = 3675,
+            Aether2 = 3676,
+            Monochrome = 3691;
+    }
+}

--- a/XIVComboPlugin/XIVComboPlugin.cs
+++ b/XIVComboPlugin/XIVComboPlugin.cs
@@ -112,6 +112,7 @@ namespace XIVComboPlugin
                 case 38: return "Dancer";
                 case 39: return "Reaper";
                 case 40: return "Sage";
+                case 42: return "Pictomancer";
             }
         }
 


### PR DESCRIPTION
Adding my 2 cents to this, hopefully helps with getting this released sooner.

### Changelog
**DRG:**
- Added "Lance Barrage" to Combo
- Added "Spiral Blow" to Combo
- Incorporated "Fang and Claw", "Wheeling Thrust" and "Drakesbane" to Combo
- Removed "High Jump" Combo as SE has baked "Mirage Dive" into the Combo

**SCH:**
- Removed the "Fey Blessing" to "Consolation" as SE has baked "Consolation" into "Seraph" Combo

**BLM:**
- Removed "Ley Lines" to "Between the Lines" combo as SE has baked "Retrace" into "Ley Lines" conflicting with this existing Combo

**PCT:**
Added my interpretation of what PCT support would look like.

- Your single button combo gets replaced with the enhanced version when you have Subtractive pallet active - why this isn't already a thing as you literally can't use the other ability otherwise makes no sense, so removed 2 useless buttons with this change

- Replaced Holy in White with Comet in Black when you have Monochrome Tones is active - again, you can't use the other ability when this buff is active or not, so why make 2 buttons??

- Merged the motif/muses, why you need a separate button to "Draw" your motif and then a separate button to cast your muse, and why is Hammer setup the way it is, draw it, activate it, stamp it, why 3 buttons??

- Merged Star Prism to Starry Sky, again, you can't cast Star Prism without the Starry Sky buff so why separate the buttons?!

Caveat to this, as SE has decided to track your Motif/Muse cooldown on your casting ability, and as we replace that with your Motif when you don't have it active and your muse when you do, you do still need to have the Muse action on your bars visible to track the CD but no longer need to press a separate button to cast it

Another caveat, I've not added any Level logic, so this really will only work fully at 100, I can't be bothered to add all the levelling logic to this myself.