### PR TITLE
Update WAR to 7.0

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -48,7 +48,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Mythril Tempest Combo", "Replace Mythril Tempest with its combo chain", 21)]
         WarriorMythrilTempestCombo = 1L << 10,
 
-        [CustomComboInfo("IR Combo", "Replace Inner Release with Primal Rend or Primal Ruination if they are ready and Wrathful status is not active", 21)]
+        [CustomComboInfo("IR Combo", "Replace Inner Release with Primal Rend or Primal Ruination when ready and not Wrathful", 21)]
         WarriorIRCombo = 1L << 63,
 
         // SAMURAI

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -48,7 +48,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Mythril Tempest Combo", "Replace Mythril Tempest with its combo chain", 21)]
         WarriorMythrilTempestCombo = 1L << 10,
 
-        [CustomComboInfo("IR to Primal Rend", "Replace Inner Release with Primal Rend when Primal Rend Ready", 21)]
+        [CustomComboInfo("IR Combo", "Replace Inner Release with Primal Rend or Primal Ruination if they are ready and Wrathful status is not active", 21)]
         WarriorIRCombo = 1L << 63,
 
         // SAMURAI

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -306,10 +306,13 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorIRCombo))
                 if (actionID == WAR.InnerRelease || actionID == WAR.Berserk)
                 {
-                    if (!SearchBuffArray(WAR.BuffWrathful) && SearchBuffArray(WAR.BuffPrimalRendReady))
-                        return WAR.PrimalRend;
-                    if (!SearchBuffArray(WAR.BuffWrathful) && SearchBuffArray(WAR.BuffPrimalRuinationReady))
-                        return WAR.PrimalRuination;
+                    if (!SearchBuffArray(WAR.BuffWrathful)
+                    {
+                        if (SearchBuffArray(WAR.BuffPrimalRendReady))
+                            return WAR.PrimalRend;
+                        if (SearchBuffArray(WAR.BuffPrimalRuinationReady))
+                            return WAR.PrimalRuination;
+                     }
                     return iconHook.Original(self, actionID);
                 }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -306,8 +306,10 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorIRCombo))
                 if (actionID == WAR.InnerRelease || actionID == WAR.Berserk)
                 {
-                    if (SearchBuffArray(WAR.BuffPrimalRendReady))
+                    if (!SearchBuffArray(WAR.BuffWrathful) && SearchBuffArray(WAR.BuffPrimalRendReady))
                         return WAR.PrimalRend;
+                    if (!SearchBuffArray(WAR.BuffWrathful) && SearchBuffArray(WAR.BuffPrimalRuinationReady))
+                        return WAR.PrimalRuination;
                     return iconHook.Original(self, actionID);
                 }
 
@@ -591,7 +593,7 @@ namespace XIVComboPlugin
                 }
 
             // ASTROLOGIAN
-
+            /**
             // Make cards on the same button as play
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.AstrologianCardsOnDrawFeature))
                 if (actionID == AST.Play)
@@ -615,6 +617,7 @@ namespace XIVComboPlugin
                             return AST.Draw;
                     }
                 }
+            */
 
             // SUMMONER
             // Change Fester into Energy Drain

--- a/XIVComboPlugin/JobActions/WAR.cs
+++ b/XIVComboPlugin/JobActions/WAR.cs
@@ -11,9 +11,12 @@
             Overpower = 41,
             InnerRelease = 7389,
             PrimalRend = 25753,
+            PrimalRuination = 36925,
             Berserk = 38;
 
         public const ushort
-            BuffPrimalRendReady = 2624;
+            BuffPrimalRendReady = 2624,
+            BuffWrathful = 3901,
+            BuffPrimalRuinationReady = 3834;
     }
 }


### PR DESCRIPTION
Simple update for WAR:

Replace Inner Release with Primal Rend or Primal Ruination if they are ready and Wrathful status is not active.

This means Primal Wrath takes priority over Rend and Ruination. Since Primal Wrath is an off-gcd, normally you want to weave it in, making it a priority over other gcd.