### PR TITLE
PCT: Standalone Motif Combo

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -190,14 +190,14 @@ namespace XIVComboPlugin
         ReaperArcaneFeature = 1L << 30,
 
         //PICTOMANCER
-        [CustomComboInfo("Additive to Subtractive Combo","Replace Additive combo with Subtractive combo when Subtractive Pallet is active",42)]
-        PictoSubtractivePallet = 1L << 31,
+        [CustomComboInfo("Additive to Subtractive Combo","Replace Additive combo with Subtractive combo when Subtractive Palette is active",42)]
+        PictoSubtractivePalette = 1L << 31,
 
         [CustomComboInfo("Motifs and Muses", "Replace Motifs with their relevant Muses", 42)]
-        PictoMotifMuseFeature = 1L << 34,
+        PictoMuseCombo = 1L << 34,
 
-        [CustomComboInfo("Landscape and Steel follow-ups", "Additionally replace Landscape Motif with Star Prism and Weapon Motif with Hammer Stamp when appropriate", 42)]
-        PictoMuseCombo = 1L << 38,
+        [CustomComboInfo("Landscape and Steel follow-ups", "Replace Landscape Motif with Star Prism and Weapon Motif with Hammer Stamp when appropriate", 42)]
+        PictoMotifCombo = 1L << 38,
 
         [CustomComboInfo("Holy White to Comet Black", "Replace Holy in White with Comet in Black when Monochrome Tones is active", 42)]
         PictoHolyWhiteCombo = 1L << 5,

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -918,7 +918,7 @@ namespace XIVComboPlugin
             }
             
              //Pictomancer
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoSubtractivePallet))
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoSubtractivePalette))
             {
                 if (actionID == PCT.Fire1)
                 {
@@ -945,12 +945,14 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMotifMuseFeature))
+            bool useMuseCombo = Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMuseCombo);
+            bool useMotifCombo = Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMotifCombo);
+            if (useMuseCombo || useMotifCombo)
             {
                 if (actionID == PCT.CreatureMotif)
                 {
                     var PCTGauge = JobGauges.Get<PCTGauge>();
-                    if (PCTGauge.CreatureMotifDrawn)
+                    if (useMuseCombo && PCTGauge.CreatureMotifDrawn)
                         return iconHook.Original(self, PCT.LivingMuse);
                     return iconHook.Original(self, actionID);
                 }
@@ -958,23 +960,21 @@ namespace XIVComboPlugin
                 if (actionID == PCT.WeaponMotif)
                 {
                     var PCTGauge = JobGauges.Get<PCTGauge>();
-                    if (PCTGauge.WeaponMotifDrawn)
+                    if (useMuseCombo && PCTGauge.WeaponMotifDrawn)
                         return iconHook.Original(self, PCT.SteelMuse);
-                    if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMuseCombo))
-                        if (SearchBuffArray(PCT.HammerReady))
-                            return iconHook.Original(self, PCT.HammerStamp);
+                    else if (useMotifCombo && SearchBuffArray(PCT.HammerReady))
+                        return iconHook.Original(self, PCT.HammerStamp);
                     return iconHook.Original(self, actionID);
                 }
 
                 if (actionID == PCT.LandscapeMotif)
                 {
                     var PCTGauge = JobGauges.Get<PCTGauge>();
-                    if (PCTGauge.LandscapeMotifDrawn)
-                        return PCT.StarryMuse;
-                    if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PictoMuseCombo))
-                        if (SearchBuffArray(PCT.StarStruck))
-                            return PCT.StarPrism;
-                    return PCT.StarryMotif;
+                    if (useMuseCombo && PCTGauge.LandscapeMotifDrawn)
+                        return iconHook.Original(self, PCT.StarryMuse);
+                    else if (useMotifCombo && SearchBuffArray(PCT.StarStruck))
+                        return iconHook.Original(self, PCT.StarPrism);
+                    return iconHook.Original(self, actionID);
                 }
             }
             


### PR DESCRIPTION
I had opened a PR for this change off of the fork Fenyn had after replying to the PR [here](https://github.com/attickdoor/XIVComboPlugin/pull/309#issuecomment-2240958522), but it looks like the PR got merged in before this could be considered, so I'll reopen it here :)

Per the comment, I think it would be great to support Weapon Motif -> Hammer Stamp / Landscape Motif -> Star Prism as a standalone combo that doesn't rely on you using the Muse combo. The reason for this being, if you use the Muse combo, once you've gone through your combo, you can no longer see the cooldowns of the Muse, since the Motif will be active button until you paint another picture. 

One could argue that you could just keep them separately somewhere just to keep track of the cooldowns, but I think that defeats the point of the plugin, and that if someone wants to have it so that the Motifs go into the relative attacks while keeping the Muses separate (such as myself), that it's a valid use case to support.