### PR TITLE
NIN: Forked/Fleeting Raiju replace Armor Crush & Aeolian Edge

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -65,10 +65,10 @@ namespace XIVComboPlugin
         SamuraiTsubameCombo = 1L << 56,
 
         // NINJA
-        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain", 30)]
+        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain, or Forked Raiju when Raiju Ready", 30)]
         NinjaArmorCrushCombo = 1L << 17,
 
-        [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain", 30)]
+        [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain, or Fleeting Raiju when Raiju Ready", 30)]
         NinjaAeolianEdgeCombo = 1L << 18,
 
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -322,6 +322,8 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaArmorCrushCombo))
                 if (actionID == NIN.ArmorCrush)
                 {
+                    if (level >= 90 && SearchBuffArray(NIN.BuffRaijuReady))
+                        return NIN.ForkedRaiju;
                     if (lastMove == NIN.SpinningEdge && level >= 4)
                         return NIN.GustSlash;
                     if (lastMove == NIN.GustSlash && level >= 54)
@@ -333,6 +335,8 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAeolianEdgeCombo))
                 if (actionID == NIN.AeolianEdge)
                 {
+                    if (level >= 90 && SearchBuffArray(NIN.BuffRaijuReady))
+                        return NIN.FleetingRaiju;
                     if (lastMove == NIN.SpinningEdge && level >= 4)
                         return NIN.GustSlash;
                     if (lastMove == NIN.GustSlash && level >= 26)

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -12,9 +12,12 @@
             DWAD = 3566,
             Assassinate = 2246,
             Bunshin = 16493,
-            PhantomK = 25774;
+            PhantomK = 25774,
+            ForkedRaiju = 25777,
+            FleetingRaiju = 25778;
 
         public const ushort
-            BuffPhantomKReady = 2723;
+            BuffPhantomKReady = 2723,
+            BuffRaijuReady = 2690;
     }
 }


### PR DESCRIPTION
New addition to NIN's basic combo chain options, to make Raijus replace the basic combo chains when Raiju Ready.

Raijus take up two buttons, can only be executed after Raiton, and can't _really_ be held because your basic combo chain will discard all currently held stacks. So, why not put them on the combo chains?

- Frees up two buttons
- Still able to choose between Forked/Fleeting (assuming you have both options enabled)
- Basic combo chains aren't intended to be used when you have Raiju stacks, so there's no conflict with putting Raijus over them